### PR TITLE
Update langgraph-checkpoint-mongodb to 0.1.0a3

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/pyproject.toml
+++ b/libs/langgraph-checkpoint-mongodb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "langgraph-checkpoint-mongodb"
-version = "0.1.0a2"
+version = "0.1.0a3"
 description = "Library with a MongoDB implementation of LangGraph checkpoint saver."
 authors = []
 license = "MIT"


### PR DESCRIPTION
We were missing permissions on the database in the last attempt.