### PR TITLE
Remove uv workspaces

### DIFF
--- a/libs/langchain-mongodb/uv.lock
+++ b/libs/langchain-mongodb/uv.lock
@@ -710,7 +710,7 @@ wheels = [
 
 [[package]]
 name = "langchain-mongodb"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,5 @@ dev = [
 ]
 
 [tool.uv.sources]
-langchain-mongodb = { workspace = true }
-langgraph-checkpoint-mongodb = { workspace = true }
-
-[tool.uv.workspace]
-members = [
-  "libs/langchain-mongodb",
-  "libs/langgraph-checkpoint-mongodb"
-]
+langchain-mongodb = { path = "libs/langchain-mongodb" }
+langgraph-checkpoint-mongodb = { path = "libs/langgraph-checkpoint-mongodb" }


### PR DESCRIPTION
The workspace concept doesn't really apply to our repo, since "Workspaces are not suited for cases in which members have conflicting requirements, or desire a separate virtual environment for each member".