### PR TITLE
INTPYTHON-495 Automatically create indexes for checkpointer collections

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -115,7 +115,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
     ) -> AsyncIterator["AsyncMongoDBSaver"]:
         """Create asynchronous checkpointer
 
-        This includes creation of collections and indexes if they don't exist.
+        This includes creation of collections and indexes if they don't exist
         """
         client: Optional[AsyncIOMotorClient] = None
         try:

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -85,13 +85,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
         self._setup_future = None
 
     async def _setup(self):
-        """Create indexes if not present.
-
-        This MUST be called by the user DIRECTLY before
-        the first time the checkpointer is used, otherwise
-        no indexes will be created. setup() will be called if checkpointer is
-        instantiated using class method `from_conn_string.
-        """
+        """Create indexes if not present."""
         if self._setup_future is not None:
             return await self._setup_future
         self._setup_future = asyncio.Future()

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -99,7 +99,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
                 keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
                 unique=True,
             )
-        self._setup_future.resolve()
+        self._setup_future.set_result(None)
 
     @classmethod
     @asynccontextmanager

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -96,7 +96,12 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
             )
         if len(await self.writes_collection.list_indexes().to_list()) < 2:
             await self.writes_collection.create_index(
-                keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
+                keys=[
+                    ("thread_id", 1),
+                    ("checkpoint_ns", 1),
+                    ("checkpoint_id", -1),
+                    ("idx", 1),
+                ],
                 unique=True,
             )
         self._setup_future.set_result(None)

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/aio.py
@@ -83,6 +83,7 @@ class AsyncMongoDBSaver(BaseCheckpointSaver):
         self.checkpoint_collection = self.db[checkpoint_collection_name]
         self.writes_collection = self.db[writes_collection_name]
         self._setup_future = None
+        self.loop = asyncio.get_running_loop()
 
     async def _setup(self):
         """Create indexes if not present."""

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -85,7 +85,12 @@ class MongoDBSaver(BaseCheckpointSaver):
             )
         if len(self.writes_collection.list_indexes().to_list()) < 2:
             self.writes_collection.create_index(
-                keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
+                keys=[
+                    ("thread_id", 1),
+                    ("checkpoint_ns", 1),
+                    ("checkpoint_id", -1),
+                    ("idx", 1),
+                ],
                 unique=True,
             )
 

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -25,7 +25,7 @@ from .utils import dumps_metadata, loads_metadata
 
 
 class MongoDBSaver(BaseCheckpointSaver):
-    """A checkpoint saver that stores StateGraph checkpoints in a MongoDB database.
+    """A checkpointer that stores StateGraph checkpoints in a MongoDB database.
 
     A compound index as shown below will be added to each of the collections
     backing the saver (checkpoints, pending writes). If the collections pre-exist,
@@ -74,14 +74,15 @@ class MongoDBSaver(BaseCheckpointSaver):
         super().__init__()
         self.client = client
         self.db = self.client[db_name]
-
         self.checkpoint_collection = self.db[checkpoint_collection_name]
+        self.writes_collection = self.db[writes_collection_name]
+
+        # Create indexes if not present
         if len(self.checkpoint_collection.list_indexes().to_list()) < 2:
             self.checkpoint_collection.create_index(
                 keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
                 unique=True,
             )
-        self.writes_collection = self.db[writes_collection_name]
         if len(self.writes_collection.list_indexes().to_list()) < 2:
             self.writes_collection.create_index(
                 keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
@@ -99,6 +100,14 @@ class MongoDBSaver(BaseCheckpointSaver):
         **kwargs: Any,
     ) -> Iterator["MongoDBSaver"]:
         """Context manager to create a MongoDB checkpoint saver.
+
+        A compound index as shown below will be added to each of the collections
+        backing the saver (checkpoints, pending writes). If the collections pre-exist,
+        and have indexes already, nothing will be done during initialization::
+
+        keys=[("thread_id", 1), ("checkpoint_ns", 1), ("checkpoint_id", -1)],
+        unique=True
+
         Args:
             conn_string: MongoDB connection string. See [class:~pymongo.MongoClient].
             db_name: Database name. It will be created if it doesn't exist.


### PR DESCRIPTION
https://jira.mongodb.org/browse/INTPYTHON-495

Note that the index creation for `AsyncMongoDBSaver` is done in a `setup` method, following what is done in the Postgres checkpointer. This is done automatically if checkpointer is created with `from_conn_string`.