### PR TITLE
[VectorStores] Override _cosine_relevance_score_fn to use cosine similarity

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/vectorstores.py
+++ b/libs/langchain-mongodb/langchain_mongodb/vectorstores.py
@@ -261,6 +261,22 @@ class MongoDBAtlasVectorSearch(VectorStore):
     def collection(self, value: Collection) -> None:
         self._collection = value
 
+    @staticmethod
+    def _cosine_relevance_score_fn(distance: float) -> float:
+        """Return the raw cosine similarity score.
+
+        This method overrides the default behavior in `VectorStore`,
+        as MongoDB Atlas Vector Search provides scores directly in
+        cosine similarity format. No normalization is required.
+
+        Args:
+            distance (float): The cosine similarity score from MongoDB.
+
+        Returns:
+            float: The raw cosine similarity score.
+        """
+        return distance
+
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         scoring: dict[str, Callable] = {
             "euclidean": self._euclidean_relevance_score_fn,


### PR DESCRIPTION
## Description  
This PR fixes an issue in **MongoDBAtlasVectorSearch** where `_cosine_relevance_score_fn` incorrectly applies **1 - distance** normalization. Since MongoDB already returns **cosine similarity scores**, this normalization is **unnecessary**. The method is overridden to return the distance directly.    

## Dependencies  
No new dependencies introduced.  