### PR TITLE
INTPYTHON-603 Add markdown link checker

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
+  rev: v5.0.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -18,7 +18,7 @@ repos:
 # We use the Python version instead of the original version which seems to require Docker
 # https://github.com/koalaman/shellcheck-precommit
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.9.0.6
+  rev: v0.10.0.1
   hooks:
     - id: shellcheck
       name: shellcheck
@@ -26,13 +26,13 @@ repos:
       stages: [manual]
 
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.29.4
+  rev: 0.33.0
   hooks:
     - id: check-github-workflows
       args: ["--verbose"]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: "v2.2.6"
+  rev: "v2.4.1"
   hooks:
   - id: codespell
     args: ["-L", "nin"]
@@ -40,13 +40,18 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.8.5
+  rev: v0.11.6
   hooks:
     # Run the linter.
     - id: ruff
       args: [ --fix ]
     # Run the formatter.
     - id: ruff-format
+
+- repo: https://github.com/tcort/markdown-link-check
+  rev: v3.13.7
+  hooks:
+    - id: markdown-link-check
 
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,6 +52,7 @@ repos:
   rev: v3.13.7
   hooks:
     - id: markdown-link-check
+      args: [-q]
 
 - repo: local
   hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v5.0.0
+  rev: v4.5.0
   hooks:
   - id: check-added-large-files
   - id: check-case-conflict
@@ -18,7 +18,7 @@ repos:
 # We use the Python version instead of the original version which seems to require Docker
 # https://github.com/koalaman/shellcheck-precommit
 - repo: https://github.com/shellcheck-py/shellcheck-py
-  rev: v0.10.0.1
+  rev: v0.9.0.6
   hooks:
     - id: shellcheck
       name: shellcheck
@@ -26,13 +26,13 @@ repos:
       stages: [manual]
 
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.33.0
+  rev: 0.29.4
   hooks:
     - id: check-github-workflows
       args: ["--verbose"]
 
 - repo: https://github.com/codespell-project/codespell
-  rev: "v2.4.1"
+  rev: "v2.2.6"
   hooks:
   - id: codespell
     args: ["-L", "nin"]
@@ -40,7 +40,7 @@ repos:
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
   # Ruff version.
-  rev: v0.11.6
+  rev: v0.8.5
   hooks:
     # Run the linter.
     - id: ruff
@@ -49,7 +49,7 @@ repos:
     - id: ruff-format
 
 - repo: https://github.com/tcort/markdown-link-check
-  rev: v3.13.7
+  rev: v3.12.2
   hooks:
     - id: markdown-link-check
       args: [-q]

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It contains the following packages.
 
 - Checkpointing (BaseCheckpointSaver)
     - [MongoDBSaver](https://langchain-mongodb.readthedocs.io/en/latest/langgraph_checkpoint_mongodb/aio/langgraph.checkpoint.mongodb.aio.AsyncMongoDBSaver.html#asyncmongodbsaver)
-    - [AsyncMongoDBSaver](https://langchain-mongodb.readthedocs.io/en/latest/langgraph_checkpoint_mongodb/saver/langgraph.checkpoint.mongodb.saver.MongoDBSaver.html#mongodbsaver)
+    - [AsyncMongoDBSaver](https://langchain-mongodb.readthedocs.io/en/latest/langgraph_scheckpoint_mongodb/saver/langgraph.checkpoint.mongodb.saver.MongoDBSaver.html#mongodbsaver)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ It contains the following packages.
 
 - Checkpointing (BaseCheckpointSaver)
     - [MongoDBSaver](https://langchain-mongodb.readthedocs.io/en/latest/langgraph_checkpoint_mongodb/aio/langgraph.checkpoint.mongodb.aio.AsyncMongoDBSaver.html#asyncmongodbsaver)
-    - [AsyncMongoDBSaver](https://langchain-mongodb.readthedocs.io/en/latest/langgraph_scheckpoint_mongodb/saver/langgraph.checkpoint.mongodb.saver.MongoDBSaver.html#mongodbsaver)
+    - [AsyncMongoDBSaver](https://langchain-mongodb.readthedocs.io/en/latest/langgraph_checkpoint_mongodb/saver/langgraph.checkpoint.mongodb.saver.MongoDBSaver.html#mongodbsaver)
 
 ## Installation
 


### PR DESCRIPTION
I verified that it catches errors by adding a bad link:

```
Markdown Link Check......................................................Failed
- hook id: markdown-link-check
- exit code: 1

(node:61496) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(Use `node --trace-deprecation ...` to show where the warning was created)

  ERROR: 1 dead links found in README.md !
  [✖] https://langchain-mongodb.readthedocs2.io/en/latest/langgraph_checkpoint_mongodb/aio/langgraph.checkpoint.mongodb.aio.AsyncMongoDBSaver.html#asyncmongodbsaver → Status: 0
```