### PR TITLE
Fix: Enhance _parse_command to robustly handle whitespace and formatting

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
+++ b/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import date, datetime
 from importlib.metadata import version
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -207,7 +208,7 @@ class MongoDBDatabase:
 
     def _parse_command(self, command: str) -> Any:
         # Convert a JavaScript command to a python object.
-        command = command.strip().replace("\n", "").replace(" ", "")
+        command = re.sub(r"\s+", " ", command.strip())
         # Handle missing closing parens.
         if command.endswith("]"):
             command += ")"


### PR DESCRIPTION
#130
Refined the `_parse_command` method from `langchain_mongodb/agent_toolkit/database.py` to normalize whitespace using regular expressions. This replaces the previous method of removing all spaces and newlines. This adjustment makes JSON parsing more resilient to different input formats, especially those resembling JavaScript syntax with irregular spacing.
