### PR TITLE
Update agent toolkit system prompt import in API reference doc

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/toolkit.py
+++ b/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/toolkit.py
@@ -56,7 +56,7 @@ class MongoDBDatabaseToolkit(BaseToolkit):
 
             from langchain import hub
             from langgraph.prebuilt import create_react_agent
-            from mongodb_agent_toolkit.prompt import MONGODB_AGENT_SYSTEM_PROMPT
+            from langchain_mongodb.agent_toolkit import MONGODB_AGENT_SYSTEM_PROMPT
 
             # Pull prompt (or define your own)
             system_message = MONGODB_AGENT_SYSTEM_PROMPT.format(top_k=5)


### PR DESCRIPTION
Hi everyone,

When trying the Text-to-MQL feature (agent_toolkit) and checking the documentation here: [API reference doc](https://langchain-mongodb.readthedocs.io/en/latest/langchain_mongodb/agent_toolkit/langchain_mongodb.agent_toolkit.toolkit.MongoDBDatabaseToolkit.html#langchain_mongodb.agent_toolkit.toolkit.MongoDBDatabaseToolkit)

I got an import error with:
`
from mongodb_agent_toolkit.prompt import MONGODB_AGENT_SYSTEM_PROMPT
`
I found out that the correct import statement is:
`from langchain_mongodb.agent_toolkit import MONGODB_AGENT_SYSTEM_PROMPT
`

With this import statement, it worked. I updated the API reference embedded doc in this PR