### PR TITLE
PYTHON-5599 Fixes [BuildFailure] [AI-ML] test_time_travel on remote

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_time_travel.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_time_travel.py
@@ -43,15 +43,12 @@ def validate_expense_node(state: ExpenseState) -> dict[str, Any]:
     ids=["ttl_none", "ttl_3600"],
 )
 def checkpointer(request: Any) -> Generator[MongoDBSaver]:
-    db_name = "langgraph_timetravel_db"
-    checkpoint_collection_name = "checkpoints"
-    writes_collection_name = "checkpoint_writes"
+    db_name = "langgraph-test"
+    checkpoint_collection_name = "timetravel_checkpoints"
+    writes_collection_name = "timetravel_writes"
 
     # Initialize MongoDB checkpointer
     client: MongoClient = MongoClient(MONGODB_URI)
-
-    # Clean up any existing test data.
-    client.drop_database(db_name)
 
     saver = MongoDBSaver(
         client=client,


### PR DESCRIPTION
Removed drop_database. Renamed db and collections to be in line with others in buildvariant.