### PR TITLE
INPYTHON-764 Make usage of text_key more obvious

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/retrievers/full_text_search.py
+++ b/libs/langchain-mongodb/langchain_mongodb/retrievers/full_text_search.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Annotated, Any, Dict, List, Optional, Union
 
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
@@ -46,7 +47,13 @@ class MongoDBAtlasFullTextSearchRetriever(BaseRetriever):
         Returns:
             List of relevant documents
         """
-        default_k = self.k if self.k is not None else self.top_k
+        is_top_k_set = False
+        with warnings.catch_warnings():
+            # Ignore warning raised by checking the value of top_k.
+            warnings.simplefilter("ignore", DeprecationWarning)
+            if self.top_k is not None:
+                is_top_k_set = True
+        default_k = self.k if not is_top_k_set else self.top_k
         pipeline = text_search_stage(  # type: ignore
             query=query,
             search_field=self.search_field,

--- a/libs/langchain-mongodb/langchain_mongodb/retrievers/hybrid_search.py
+++ b/libs/langchain-mongodb/langchain_mongodb/retrievers/hybrid_search.py
@@ -86,12 +86,12 @@ class MongoDBAtlasHybridSearchRetriever(BaseRetriever):
         # Get the appropriate value for k.
         is_top_k_set = False
         with warnings.catch_warnings():
-            # Ignore warnings raised by base class.
+            # Ignore warning raised by checking the value of top_k.
             warnings.simplefilter("ignore", DeprecationWarning)
             if self.top_k is not None:
                 is_top_k_set = True
         default_k = self.k if not is_top_k_set else self.top_k
-        k = kwargs.get("k", default_k)
+        k: int = kwargs.get("k", default_k)  # type:ignore[assignment]
 
         # First we build up the aggregation pipeline,
         # then it is passed to the server to execute

--- a/libs/langchain-mongodb/langchain_mongodb/retrievers/hybrid_search.py
+++ b/libs/langchain-mongodb/langchain_mongodb/retrievers/hybrid_search.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Annotated, Any, Dict, List, Optional
 
 from langchain_core.callbacks.manager import CallbackManagerForRetrieverRun
@@ -83,7 +84,13 @@ class MongoDBAtlasHybridSearchRetriever(BaseRetriever):
         pipeline: List[Any] = []
 
         # Get the appropriate value for k.
-        default_k = self.top_k if self.top_k is not None else self.k
+        is_top_k_set = False
+        with warnings.catch_warnings():
+            # Ignore warnings raised by base class.
+            warnings.simplefilter("ignore", DeprecationWarning)
+            if self.top_k is not None:
+                is_top_k_set = True
+        default_k = self.k if not is_top_k_set else self.top_k
         k = kwargs.get("k", default_k)
 
         # First we build up the aggregation pipeline,

--- a/libs/langchain-mongodb/langchain_mongodb/vectorstores.py
+++ b/libs/langchain-mongodb/langchain_mongodb/vectorstores.py
@@ -828,7 +828,7 @@ class MongoDBAtlasVectorSearch(VectorStore):
         ):
             warnings.warn(
                 f"Could not find any documents with the text_key: '{self._text_key}'",
-                stacklevel=2,
+                stacklevel=1,
             )
         return docs
 

--- a/libs/langchain-mongodb/pyproject.toml
+++ b/libs/langchain-mongodb/pyproject.toml
@@ -45,13 +45,20 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
+minversion = "7"
 addopts = "--snapshot-warn-unused --strict-markers --strict-config --durations=5"
+log_cli_level = "INFO"
+faulthandler_timeout = 1500
+xfail_strict = true
 markers = [
     "requires: mark tests as requiring a specific library",
     "compile: mark placeholder test used to compile integration tests without running them",
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
+filterwarnings = [
+    "error"
+]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/libs/langchain-mongodb/tests/integration_tests/conftest.py
+++ b/libs/langchain-mongodb/tests/integration_tests/conftest.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from typing import Generator, List
 
 import pytest
@@ -16,7 +17,10 @@ from ..utils import CONNECTION_STRING
 def technical_report_pages() -> List[Document]:
     """Returns a Document for each of the 100 pages of a GPT-4 Technical Report"""
     loader = PyPDFLoader("https://arxiv.org/pdf/2303.08774.pdf")
-    pages = loader.load()
+    with warnings.catch_warnings():
+        # Ignore warnings raised by base class.
+        warnings.simplefilter("ignore", ResourceWarning)
+        pages = loader.load()
     return pages
 
 

--- a/libs/langchain-mongodb/tests/integration_tests/test_agent_toolkit.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_agent_toolkit.py
@@ -74,3 +74,4 @@ def test_toolkit_response(db):
     for event in events:
         messages.extend(event["messages"])
     assert "USA" in messages[-1].content, messages[-1].content
+    db_wrapper.close()

--- a/libs/langchain-mongodb/tests/integration_tests/test_cache.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_cache.py
@@ -157,6 +157,7 @@ def test_mongodb_cache(
         _execute_test(prompt, llm, response)
     finally:
         get_llm_cache().clear()
+        get_llm_cache().close()
 
 
 @pytest.mark.parametrize(
@@ -208,3 +209,4 @@ def test_mongodb_atlas_cache_matrix(
         generations=llm_generations, llm_output={}
     )
     get_llm_cache().clear()
+    get_llm_cache().close()

--- a/libs/langchain-mongodb/tests/integration_tests/test_cache.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_cache.py
@@ -157,7 +157,7 @@ def test_mongodb_cache(
         _execute_test(prompt, llm, response)
     finally:
         get_llm_cache().clear()
-        get_llm_cache().close()
+        get_llm_cache().close()  # type:ignore[attr-defined]
 
 
 @pytest.mark.parametrize(
@@ -209,4 +209,4 @@ def test_mongodb_atlas_cache_matrix(
         generations=llm_generations, llm_output={}
     )
     get_llm_cache().clear()
-    get_llm_cache().close()
+    get_llm_cache().close()  # type:ignore[attr-defined]

--- a/libs/langchain-mongodb/tests/integration_tests/test_cache.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_cache.py
@@ -70,7 +70,7 @@ def llm_cache(cls: Any) -> BaseCache:
         )
     )
     assert get_llm_cache()
-    return get_llm_cache()
+    return get_llm_cache()  # type:ignore[return-value]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -99,7 +99,7 @@ def _execute_test(
     dumped_prompt: str = prompt if isinstance(prompt, str) else dumps(prompt)
 
     # Update the cache
-    get_llm_cache().update(dumped_prompt, llm_string, response)
+    get_llm_cache().update(dumped_prompt, llm_string, response)  # type:ignore[union-attr]
 
     # Retrieve the cached result through 'generate' call
     output: Union[List[Generation], LLMResult, None]
@@ -156,8 +156,8 @@ def test_mongodb_cache(
     try:
         _execute_test(prompt, llm, response)
     finally:
-        get_llm_cache().clear()
-        get_llm_cache().close()  # type:ignore[attr-defined]
+        get_llm_cache().clear()  # type:ignore[union-attr]
+        get_llm_cache().close()  # type:ignore[attr-defined,union-attr]
 
 
 @pytest.mark.parametrize(
@@ -208,5 +208,5 @@ def test_mongodb_atlas_cache_matrix(
     assert llm.generate(prompts) == LLMResult(
         generations=llm_generations, llm_output={}
     )
-    get_llm_cache().clear()
-    get_llm_cache().close()  # type:ignore[attr-defined]
+    get_llm_cache().clear()  # type:ignore[union-attr]
+    get_llm_cache().close()  # type:ignore[attr-defined,union-attr]

--- a/libs/langchain-mongodb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_chat_message_histories.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 from langchain.memory import ConversationBufferMemory  # type: ignore[import-not-found]
 from langchain_core.messages import message_to_dict
@@ -19,9 +20,12 @@ def test_memory_with_message_store() -> None:
         database_name=DB_NAME,
         collection_name=COLLECTION,
     )
-    memory = ConversationBufferMemory(
-        memory_key="baz", chat_memory=message_history, return_messages=True
-    )
+    with warnings.catch_warnings():
+        # Ignore warnings raised by base class.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        memory = ConversationBufferMemory(
+            memory_key="baz", chat_memory=message_history, return_messages=True
+        )
 
     # add some messages
     memory.chat_memory.add_ai_message("This is me, the AI")
@@ -38,3 +42,4 @@ def test_memory_with_message_store() -> None:
     memory.chat_memory.clear()
 
     assert memory.chat_memory.messages == []
+    memory.chat_memory.close()

--- a/libs/langchain-mongodb/tests/integration_tests/test_chat_message_histories.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_chat_message_histories.py
@@ -42,4 +42,4 @@ def test_memory_with_message_store() -> None:
     memory.chat_memory.clear()
 
     assert memory.chat_memory.messages == []
-    memory.chat_memory.close()
+    memory.chat_memory.close()  # type:ignore[attr-defined]

--- a/libs/langchain-mongodb/tests/integration_tests/test_parent_document.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_parent_document.py
@@ -74,3 +74,4 @@ def test_1clxn_retriever(
     assert len(responses) == 3
     assert all("GPT-4" in doc.page_content for doc in responses)
     assert {4, 5, 29} == set(doc.metadata["page"] for doc in responses)
+    client.close()

--- a/libs/langchain-mongodb/tests/integration_tests/test_retrievers.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_retrievers.py
@@ -194,12 +194,14 @@ def test_hybrid_retriever_deprecated_top_k(
     )
 
     query1 = "When did I visit France?"
-    results = retriever.invoke(query1)
+    with pytest.warns(DeprecationWarning):
+        results = retriever.invoke(query1)
     assert len(results) == 3
     assert "Paris" in results[0].page_content
 
     query2 = "When was the last time I visited new orleans?"
-    results = retriever.invoke(query2)
+    with pytest.warns(DeprecationWarning):
+        results = retriever.invoke(query2)
     assert "New Orleans" in results[0].page_content
 
 

--- a/libs/langchain-mongodb/tests/integration_tests/test_retrievers_multi_field.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_retrievers_multi_field.py
@@ -207,12 +207,14 @@ def test_hybrid_retriever_deprecated_top_k(
     )
 
     query1 = "When did I visit France?"
-    results = retriever.invoke(query1)
+    with pytest.warns(DeprecationWarning):
+        results = retriever.invoke(query1)
     assert len(results) == 3
     assert "Paris" in results[0].page_content
 
     query2 = "When was the last time I visited new orleans?"
-    results = retriever.invoke(query2)
+    with pytest.warns(DeprecationWarning):
+        results = retriever.invoke(query2)
     assert "New Orleans" in results[0].page_content
 
 

--- a/libs/langchain-mongodb/tests/integration_tests/test_retrievers_standard.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_retrievers_standard.py
@@ -66,7 +66,7 @@ def setup_test(coll: Collection) -> MongoDBAtlasVectorSearch:
             wait_until_complete=TIMEOUT,
         )
 
-    return coll, vs
+    return vs
 
 
 class TestMongoDBAtlasFullTextSearchRetriever(RetrieversIntegrationTests):

--- a/libs/langchain-mongodb/tests/integration_tests/test_retrievers_standard.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_retrievers_standard.py
@@ -68,6 +68,8 @@ def setup_test() -> tuple[Collection, MongoDBAtlasVectorSearch]:
 
 
 class TestMongoDBAtlasFullTextSearchRetriever(RetrieversIntegrationTests):
+    _coll: Collection
+
     @classmethod
     def setup_class(cls):
         cls._coll, _ = setup_test()
@@ -98,6 +100,9 @@ class TestMongoDBAtlasFullTextSearchRetriever(RetrieversIntegrationTests):
 
 
 class TestMongoDBAtlasHybridSearchRetriever(RetrieversIntegrationTests):
+    _coll: Collection
+    _vs: MongoDBAtlasVectorSearch
+
     @classmethod
     def setup_class(cls):
         cls._coll, cls._vs = setup_test()

--- a/libs/langchain-mongodb/tests/integration_tests/test_tools.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_tools.py
@@ -12,13 +12,21 @@ from tests.utils import create_database, create_llm
 
 
 class TestQueryMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
+    @classmethod
+    def setup_class(cls):
+        cls._db = create_database()
+
+    @classmethod
+    def teardown_class(cls):
+        cls._db.close()
+
     @property
     def tool_constructor(self) -> Type[QueryMongoDBDatabaseTool]:
         return QueryMongoDBDatabaseTool
 
     @property
     def tool_constructor_params(self) -> dict:
-        return dict(db=create_database())
+        return dict(db=self._db)
 
     @property
     def tool_invoke_params_example(self) -> dict:
@@ -26,13 +34,21 @@ class TestQueryMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
 
 
 class TestInfoMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
+    @classmethod
+    def setup_class(cls):
+        cls._db = create_database()
+
+    @classmethod
+    def teardown_class(cls):
+        cls._db.close()
+
     @property
     def tool_constructor(self) -> Type[InfoMongoDBDatabaseTool]:
         return InfoMongoDBDatabaseTool
 
     @property
     def tool_constructor_params(self) -> dict:
-        return dict(db=create_database())
+        return dict(db=self._db)
 
     @property
     def tool_invoke_params_example(self) -> dict:
@@ -40,13 +56,21 @@ class TestInfoMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
 
 
 class TestListMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
+    @classmethod
+    def setup_class(cls):
+        cls._db = create_database()
+
+    @classmethod
+    def teardown_class(cls):
+        cls._db.close()
+
     @property
     def tool_constructor(self) -> Type[ListMongoDBDatabaseTool]:
         return ListMongoDBDatabaseTool
 
     @property
     def tool_constructor_params(self) -> dict:
-        return dict(db=create_database())
+        return dict(db=self._db)
 
     @property
     def tool_invoke_params_example(self) -> dict:
@@ -54,13 +78,21 @@ class TestListMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
 
 
 class TestQueryMongoDBCheckerToolIntegration(ToolsIntegrationTests):
+    @classmethod
+    def setup_class(cls):
+        cls._db = create_database()
+
+    @classmethod
+    def teardown_class(cls):
+        cls._db.close()
+
     @property
     def tool_constructor(self) -> Type[QueryMongoDBCheckerTool]:
         return QueryMongoDBCheckerTool
 
     @property
     def tool_constructor_params(self) -> dict:
-        return dict(db=create_database(), llm=create_llm())
+        return dict(db=self._db, llm=create_llm())
 
     @property
     def tool_invoke_params_example(self) -> dict:

--- a/libs/langchain-mongodb/tests/integration_tests/test_tools.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_tools.py
@@ -1,17 +1,24 @@
 from typing import Type
 
+import pytest
 from langchain_tests.integration_tests import ToolsIntegrationTests
 
 from langchain_mongodb.agent_toolkit.tool import (
     InfoMongoDBDatabaseTool,
     ListMongoDBDatabaseTool,
+    MongoDBDatabase,
     QueryMongoDBCheckerTool,
     QueryMongoDBDatabaseTool,
 )
 from tests.utils import create_database, create_llm
 
+# Ignore ResourceWarning raised by base class.
+pytestmark = pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
+
 
 class TestQueryMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
+    _db: MongoDBDatabase
+
     @classmethod
     def setup_class(cls):
         cls._db = create_database()
@@ -34,6 +41,8 @@ class TestQueryMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
 
 
 class TestInfoMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
+    _db: MongoDBDatabase
+
     @classmethod
     def setup_class(cls):
         cls._db = create_database()
@@ -56,6 +65,8 @@ class TestInfoMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
 
 
 class TestListMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
+    _db: MongoDBDatabase
+
     @classmethod
     def setup_class(cls):
         cls._db = create_database()
@@ -78,6 +89,8 @@ class TestListMongoDBDatabaseToolIntegration(ToolsIntegrationTests):
 
 
 class TestQueryMongoDBCheckerToolIntegration(ToolsIntegrationTests):
+    _db: MongoDBDatabase
+
     @classmethod
     def setup_class(cls):
         cls._db = create_database()

--- a/libs/langchain-mongodb/tests/integration_tests/test_vectorstore_add_delete.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_vectorstore_add_delete.py
@@ -252,6 +252,6 @@ def test_warning_for_misaligned_text_key(
 
     assert len(record) == 1
     assert (
-        record[0].message.args[0]
+        record[0].message.args[0]  # type:ignore[union-attr]
         == "Could not find any documents with the text_key: 'text'"
     )

--- a/libs/langchain-mongodb/tests/integration_tests/test_vectorstore_standard.py
+++ b/libs/langchain-mongodb/tests/integration_tests/test_vectorstore_standard.py
@@ -19,6 +19,10 @@ INDEX_NAME = "langchain-test-index-standard"
 DIMENSIONS = 6
 
 
+# Ignore ResourceWarning raised by base class.
+pytestmark = pytest.mark.filterwarnings("ignore:unclosed:ResourceWarning")
+
+
 @pytest.fixture
 def collection(client: MongoClient) -> Collection:
     if COLLECTION_NAME not in client[DB_NAME].list_collection_names():

--- a/libs/langchain-mongodb/tests/unit_tests/test_cache.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_cache.py
@@ -81,7 +81,7 @@ def llm_cache(cls: Any) -> BaseCache:
         )
     )
     assert get_llm_cache()
-    return get_llm_cache()
+    return get_llm_cache()  # type:ignore[return-value]
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -111,6 +111,7 @@ def _execute_test(
 
     # Update the cache
     llm_cache = get_llm_cache()
+    assert llm_cache is not None
     llm_cache.update(dumped_prompt, llm_string, response)
 
     # Retrieve the cached result through 'generate' call
@@ -175,7 +176,7 @@ def test_mongodb_cache(
     try:
         _execute_test(prompt, llm, response)
     finally:
-        get_llm_cache().clear()
+        get_llm_cache().clear()  # type:ignore[union-attr]
 
 
 @pytest.mark.parametrize(
@@ -227,4 +228,4 @@ def test_mongodb_atlas_cache_matrix(
     assert llm.generate(prompts) == LLMResult(
         generations=llm_generations, llm_output={}
     )
-    get_llm_cache().clear()
+    get_llm_cache().clear()  # type:ignore[union-attr]

--- a/libs/langchain-mongodb/tests/unit_tests/test_chat_message_histories.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_chat_message_histories.py
@@ -1,4 +1,5 @@
 import json
+import warnings
 
 import mongomock
 import pytest
@@ -29,9 +30,12 @@ def test_memory_with_message_store() -> None:
     """Test the memory with a message store."""
     # setup MongoDB as a message store
     message_history = PatchedMongoDBChatMessageHistory()
-    memory = ConversationBufferMemory(
-        memory_key="baz", chat_memory=message_history, return_messages=True
-    )
+    with warnings.catch_warnings():
+        # Ignore warnings raised by base class.
+        warnings.simplefilter("ignore", DeprecationWarning)
+        memory = ConversationBufferMemory(
+            memory_key="baz", chat_memory=message_history, return_messages=True
+        )
 
     # add some messages
     memory.chat_memory.add_ai_message("This is me, the AI")

--- a/libs/langchain-mongodb/tests/unit_tests/test_index.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_index.py
@@ -13,7 +13,7 @@ TIMEOUT = 120
 
 
 @pytest.fixture
-def collection() -> Generator[None, None, Collection]:
+def collection() -> Generator[Collection, None, None]:
     """Collection on MongoDB Cluster, not an Atlas one."""
     client: MongoClient = MongoClient()
     yield client["db"]["collection"]

--- a/libs/langchain-mongodb/tests/unit_tests/test_index.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_index.py
@@ -13,7 +13,7 @@ TIMEOUT = 120
 
 
 @pytest.fixture
-def collection() -> Generator[Collection]:
+def collection() -> Generator[None, Collection]:
     """Collection on MongoDB Cluster, not an Atlas one."""
     client: MongoClient = MongoClient()
     yield client["db"]["collection"]

--- a/libs/langchain-mongodb/tests/unit_tests/test_index.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_index.py
@@ -15,7 +15,8 @@ TIMEOUT = 120
 def collection() -> Collection:
     """Collection on MongoDB Cluster, not an Atlas one."""
     client: MongoClient = MongoClient()
-    return client["db"]["collection"]
+    yield client["db"]["collection"]
+    client.close()
 
 
 def test_create_vector_search_index(collection: Collection) -> None:

--- a/libs/langchain-mongodb/tests/unit_tests/test_index.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_index.py
@@ -13,7 +13,7 @@ TIMEOUT = 120
 
 
 @pytest.fixture
-def collection() -> Generator[None, Collection]:
+def collection() -> Generator[None, None, Collection]:
     """Collection on MongoDB Cluster, not an Atlas one."""
     client: MongoClient = MongoClient()
     yield client["db"]["collection"]

--- a/libs/langchain-mongodb/tests/unit_tests/test_index.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_index.py
@@ -1,4 +1,5 @@
 from time import sleep
+from typing import Generator
 
 import pytest
 from pymongo import MongoClient
@@ -12,7 +13,7 @@ TIMEOUT = 120
 
 
 @pytest.fixture
-def collection() -> Collection:
+def collection() -> Generator[Collection]:
     """Collection on MongoDB Cluster, not an Atlas one."""
     client: MongoClient = MongoClient()
     yield client["db"]["collection"]


### PR DESCRIPTION
Patch build: https://spruce.mongodb.com/version/68e3e465cef4a80007fa957e/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC

Turning on warnings exposed some other places where we weren't handling warnings well, especially with `top_k`, which was always triggering a warning just by us accessing it.  There were also several places where we were not explicitly closing clients in tests.