### PR TITLE
Fixing MongoDBDatabase init to only list authorized collections

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
+++ b/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
@@ -57,7 +57,7 @@ class MongoDBDatabase:
             )
         self._include_colls = set(include_collections or [])
         self._ignore_colls = set(ignore_collections or [])
-        self._all_colls = set(self._db.list_collection_names())
+        self._all_colls = set(self._db.list_collection_names(authorizedCollections=True))
 
         self._sample_docs_in_coll_info = sample_docs_in_collection_info
         self._indexes_in_coll_info = indexes_in_collection_info


### PR DESCRIPTION
Fixing MongoDBDatabase init to only list authorized collections. Fixes #225 