### PR TITLE
INTPYTHON-780 Make TestMongoDBAtlasFullTextSearchRetriever more robust

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/retrievers/full_text_search.py
+++ b/libs/langchain-mongodb/langchain_mongodb/retrievers/full_text_search.py
@@ -54,7 +54,6 @@ class MongoDBAtlasFullTextSearchRetriever(BaseRetriever):
             if self.top_k is not None:
                 is_top_k_set = True
         default_k = self.k if not is_top_k_set else self.top_k
-        print(f"{is_top_k_set=}, {self.k=}, {default_k=}, {kwargs=}")
         pipeline = text_search_stage(  # type: ignore
             query=query,
             search_field=self.search_field,

--- a/libs/langchain-mongodb/pyproject.toml
+++ b/libs/langchain-mongodb/pyproject.toml
@@ -56,9 +56,9 @@ markers = [
 ]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-# filterwarnings = [
-#     "error"
-# ]
+filterwarnings = [
+    "error"
+]
 
 [tool.mypy]
 disallow_untyped_defs = true


### PR DESCRIPTION
Patch build (the three most recent executions): https://spruce.mongodb.com/task/ai_ml_pipeline_testing_test_langchain_python_rhel_test_langchain_python_remote_patch_d0e1c48628390d90fcefb0e04d272978026b86b5_68e686af2e09ea00080015d9_25_10_08_15_44_15/logs?execution=9

Reverts to be closer to the original behavior prior to #220 