### PR TITLE
Bump langgraph-checkpoint-mongodb version to 0.2.2 and update locks

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/pyproject.toml
+++ b/libs/langgraph-checkpoint-mongodb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint-mongodb"
-version = "0.2.1"
+version = "0.2.2"
 description = "Library with a MongoDB implementation of LangGraph checkpoint saver."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/libs/langgraph-checkpoint-mongodb/uv.lock
+++ b/libs/langgraph-checkpoint-mongodb/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-mongodb"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-mongodb" },

--- a/uv.lock
+++ b/uv.lock
@@ -886,7 +886,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-mongodb"
-version = "0.2.1"
+version = "0.2.2"
 source = { editable = "libs/langgraph-checkpoint-mongodb" }
 dependencies = [
     { name = "langchain-mongodb" },


### PR DESCRIPTION
Prep for 0.2.2 release.