### PR TITLE
INTPYTHON-841 Remove py39 fallback from typing.TypeAlias

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/graphrag/graph.py
+++ b/libs/langchain-mongodb/langchain_mongodb/graphrag/graph.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, TypeAlias, Union
 
 from langchain_core.documents import Document
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -21,11 +21,6 @@ from .prompts import rag_prompt
 from .schema import entity_schema
 
 if TYPE_CHECKING:
-    try:
-        from typing import TypeAlias  # type:ignore[attr-defined] # Python 3.10+
-    except ImportError:  # Python 3.9 fallback  # TODO Remove [PYTHON-5658]
-        from typing_extensions import TypeAlias
-
     Entity: TypeAlias = Dict[str, Any]
     """Represents an Entity in the knowledge graph with specific schema. See .schema"""
 


### PR DESCRIPTION
INTPYTHON-841

## Summary

<!-- What is this PR introducing? If context is already provided from the JIRA ticket, still place it in the Pull Request as you should not make the reviewer do digging for a basic summary. -->

One line change to remove fallback to get TypeAlias from typing_extensions for python 3.9.

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [X] Did you update the changelog (if necessary)?
- [X] Is the intention of the code captured in relevant tests?
- [X] If there are new TODOs, has a related JIRA ticket been created?
- [X] Has a MongoDB Employee run [the patch build of this PR](https://github.com/mongodb-labs/ai-ml-pipeline-testing?tab=readme-ov-file#running-a-patch-build-of-a-given-pr)?

### Checklist for Reviewer {@primary_reviewer}

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?

## Focus Areas for Reviewer (optional)

<!-- List any complex portion of code you believe needs particular scrutiny and explain why.  -->

[Evergreen Patch Link](https://spruce.mongodb.com/version/692f61ec37f69f0007aa54e6)