### PR TITLE
INTPYTHON-860 Bump langchain-core dependency for CVE-2025-68664

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dev = [
     "sphinx>=7.4.7",
     "sphinx-copybutton>=0.5.2",
     "toml>=0.10.2",
-    "langchain-core>=1.0.0",
+    "langchain-core>=1.2.5",
     "sphinxcontrib-googleanalytics>=0.4",
     "langchain-mongodb",
     "langgraph-checkpoint-mongodb",


### PR DESCRIPTION
INTPYTHON-860

Critical CVE:
https://cyata.ai/blog/langgrinch-langchain-core-cve-2025-68664/

sign-off-by: Deelvesh Bunjun


