### PR TITLE
fix: handle Firestore MongoDB-compatible endpoint that lacks authorizedCollections

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
+++ b/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
@@ -57,9 +57,14 @@ class MongoDBDatabase:
             )
         self._include_colls = set(include_collections or [])
         self._ignore_colls = set(ignore_collections or [])
-        self._all_colls = set(
-            self._db.list_collection_names(authorizedCollections=True)
-        )
+        # Try with authorizedCollections=True first, fall back to False
+        # for MongoDB-compatible endpoints (e.g., Firestore) that don't support it
+        try:
+            self._all_colls = set(
+                self._db.list_collection_names(authorizedCollections=True)
+            )
+        except PyMongoError:
+            self._all_colls = set(self._db.list_collection_names())
 
         self._sample_docs_in_coll_info = sample_docs_in_collection_info
         self._indexes_in_coll_info = indexes_in_collection_info


### PR DESCRIPTION
## Summary

Fixes MongoDBDatabase initialization failure when connecting to Firestore's MongoDB-compatible endpoint.

**Problem:**
Firestore's MongoDB-compatible endpoint does not support the `authorizedCollections` parameter in the `listCollections` command, causing:

```
pymongo.errors.OperationFailure: authorizedCollections is not supported
```

**Solution:**
Catch the `PyMongoError` when calling `list_collections_names(authorizedCollections=True)` fails, and fall back to calling it without the parameter.

**Code Change:**

```python
# Try with authorizedCollections=True first, fall back to False
# for MongoDB-compatible endpoints (e.g., Firestore) that don't support it
try:
    self._all_colls = set(
        self._db.list_collection_names(authorizedCollections=True)
    )
except PyMongoError:
    self._all_colls = set(self._db.list_collection_names())
```

Fixes langchain-ai/langchain#36609