### PR TITLE
fix: handle authorizedCollections=True for Firestore MongoDB compatibility

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
+++ b/libs/langchain-mongodb/langchain_mongodb/agent_toolkit/database.py
@@ -57,9 +57,12 @@ class MongoDBDatabase:
             )
         self._include_colls = set(include_collections or [])
         self._ignore_colls = set(ignore_collections or [])
-        self._all_colls = set(
-            self._db.list_collection_names(authorizedCollections=True)
-        )
+        try:
+            self._all_colls = set(
+                self._db.list_collection_names(authorizedCollections=True)
+            )
+        except PyMongoError:
+            self._all_colls = set(self._db.list_collection_names())
 
         self._sample_docs_in_coll_info = sample_docs_in_collection_info
         self._indexes_in_coll_info = indexes_in_collection_info

--- a/libs/langchain-mongodb/langchain_mongodb/cache.py
+++ b/libs/langchain-mongodb/langchain_mongodb/cache.py
@@ -13,6 +13,7 @@ from langchain_core.outputs import Generation
 from pymongo import MongoClient
 from pymongo.collection import Collection
 from pymongo.database import Database
+from pymongo.errors import PyMongoError
 
 from langchain_mongodb.utils import DRIVER_METADATA
 from langchain_mongodb.vectorstores import MongoDBAtlasVectorSearch
@@ -52,9 +53,13 @@ class MongoDBCache(BaseCache):
         self.__database_name = database_name
         self.__collection_name = collection_name
 
-        if self.__collection_name not in self.database.list_collection_names(
-            authorizedCollections=True
-        ):
+        try:
+            coll_names = self.database.list_collection_names(
+                authorizedCollections=True
+            )
+        except PyMongoError:
+            coll_names = self.database.list_collection_names()
+        if self.__collection_name not in coll_names:
             self.database.create_collection(self.__collection_name)
             # Create an index on key and llm_string
             self.collection.create_index([self.PROMPT, self.LLM])

--- a/libs/langchain-mongodb/langchain_mongodb/graphrag/graph.py
+++ b/libs/langchain-mongodb/langchain_mongodb/graphrag/graph.py
@@ -11,7 +11,7 @@ from langchain_core.messages import BaseMessage
 from langchain_core.prompts.chat import ChatPromptTemplate
 from pymongo import MongoClient, UpdateOne
 from pymongo.collection import Collection
-from pymongo.errors import OperationFailure
+from pymongo.errors import OperationFailure, PyMongoError
 from pymongo.results import BulkWriteResult
 
 from langchain_mongodb.graphrag import example_templates, prompts
@@ -140,9 +140,13 @@ class MongoDBGraphStore:
                 driver=DRIVER_METADATA,
             )
             db = client[database_name]
-            if collection_name not in db.list_collection_names(
-                authorizedCollections=True
-            ):
+            try:
+                coll_names = db.list_collection_names(
+                    authorizedCollections=True
+                )
+            except PyMongoError:
+                coll_names = db.list_collection_names()
+            if collection_name not in coll_names:
                 validator = {"$jsonSchema": self._schema} if validate else None
                 collection = client[database_name].create_collection(
                     collection_name,


### PR DESCRIPTION
## Summary

Firestore and other non-native MongoDB backends do not support the `authorizedCollections` parameter in `list_collection_names()`, causing an `OperationFailure` at initialization.

This wraps all three call sites (`database.py`, `cache.py`, `graphrag/graph.py`) in try/except so they gracefully degrade to the parameter-less version when a `PyMongoError` is raised.

Fixes langchain-ai/langchain#36609

## Changes

- **`agent_toolkit/database.py`**: wrap `list_collection_names(authorizedCollections=True)` in try/except
- **`cache.py`**: same fix for MongoDBCache initialization
- **`graphrag/graph.py`**: same fix for graph collection initialization

## Testing

Existing tests should pass. The try/except path only activates when `authorizedCollections` is rejected by the server, which is the exact scenario described in the issue.