### PR TITLE
INTPYTHON-957: test upgrade path from legacy multikey index

### DIFF
--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
@@ -4,6 +4,7 @@ from collections.abc import Generator
 from datetime import datetime
 
 import pytest
+from bson import SON
 from langgraph.store.base import (
     GetOp,
     Item,
@@ -392,3 +393,163 @@ def test_search_basic(store: MongoDBStore) -> None:
     store.put(namespace=namespace, key="id_foo", value={"data": "value_foo"})
     result = store.search(namespace, filter={"data": "value_foo"})
     assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# INTPYTHON-957: upgrade path from the legacy (namespace, key) multikey index
+# to the new (namespace_str, key) unique index, plus namespace_str backfill.
+# ---------------------------------------------------------------------------
+
+LEGACY_COLLECTION_NAME = "long_term_memory_legacy"
+
+NS_KEY = SON([("namespace", 1), ("key", 1)])
+NS_STR_KEY = SON([("namespace_str", 1), ("key", 1)])
+
+
+@pytest.fixture
+def legacy_collection() -> Generator:
+    """A clean collection for legacy/upgrade tests, isolated from the shared fixture."""
+    client: MongoClient = MongoClient(MONGODB_URI)
+    collection = client[DB_NAME][LEGACY_COLLECTION_NAME]
+    collection.delete_many({})
+    collection.drop_indexes()
+    try:
+        yield collection
+    finally:
+        collection.delete_many({})
+        collection.drop_indexes()
+        client.close()
+
+
+def _index_by_key(collection, key_pattern):  # type: ignore[no-untyped-def]
+    return next(
+        (idx for idx in collection.list_indexes() if idx["key"] == key_pattern), None
+    )
+
+
+def test_upgrade_from_legacy_index(legacy_collection) -> None:  # type: ignore[no-untyped-def]
+    """Existing collection with the legacy (namespace, key) unique multikey index
+    and pre-existing documents lacking namespace_str should be migrated on init:
+
+    - Every legacy document gains namespace_str = "/".join(namespace).
+    - The legacy (namespace, key) index is dropped.
+    - A unique (namespace_str, key) index is created.
+    - Reads and writes against the migrated docs work correctly.
+    """
+    legacy_collection.create_index([("namespace", 1), ("key", 1)], unique=True)
+
+    now = datetime.now()
+    legacy_docs = [
+        {
+            "namespace": list(ns),
+            "key": key,
+            "value": value,
+            "created_at": now,
+            "updated_at": now,
+        }
+        for ns, key, value in [
+            (("users", "alice", "preferences"), "food", {"likes": "pizza"}),
+            (("users", "bob"), "profile", {"name": "Bob"}),
+            (("admin",), "root", {"role": "superuser"}),
+            (("a", "b", "c"), "x", {"v": 1}),
+        ]
+    ]
+    legacy_collection.insert_many(legacy_docs)
+    assert legacy_collection.count_documents({"namespace_str": {"$exists": True}}) == 0
+
+    store = MongoDBStore(legacy_collection)
+
+    # Every doc backfilled.
+    assert legacy_collection.count_documents({"namespace_str": {"$exists": False}}) == 0
+    for doc in legacy_collection.find({}):
+        assert doc["namespace_str"] == "/".join(doc["namespace"])
+
+    # Legacy index gone, new unique index present.
+    assert _index_by_key(legacy_collection, NS_KEY) is None
+    new_idx = _index_by_key(legacy_collection, NS_STR_KEY)
+    assert new_idx is not None
+    assert new_idx.get("unique") is True
+
+    # Reads return the original values.
+    alice = store.get(("users", "alice", "preferences"), "food")
+    assert alice is not None and alice.value == {"likes": "pizza"}
+
+    # Writes against a legacy (namespace, key) update in place rather than insert,
+    # proving uniqueness now keys off namespace_str.
+    n_before = legacy_collection.count_documents({})
+    store.put(("a", "b", "c"), "x", {"v": 2})
+    assert legacy_collection.count_documents({}) == n_before
+    updated = store.get(("a", "b", "c"), "x")
+    assert updated is not None and updated.value == {"v": 2}
+
+
+def test_upgrade_with_conflicting_non_unique_index(legacy_collection) -> None:  # type: ignore[no-untyped-def]
+    """A pre-existing non-unique (namespace_str, key) index should be dropped
+    and replaced with the unique variant on init."""
+    legacy_collection.create_index([("namespace_str", 1), ("key", 1)], unique=False)
+
+    pre = _index_by_key(legacy_collection, NS_STR_KEY)
+    assert pre is not None and not pre.get("unique", False)
+
+    MongoDBStore(legacy_collection)
+
+    # Exactly one index on (namespace_str, key), and it must be unique.
+    matches = [
+        idx for idx in legacy_collection.list_indexes() if idx["key"] == NS_STR_KEY
+    ]
+    assert len(matches) == 1
+    assert matches[0].get("unique") is True
+
+
+def test_upgrade_idempotent(legacy_collection) -> None:  # type: ignore[no-untyped-def]
+    """Re-initializing MongoDBStore against an already-migrated collection
+    should be a no-op: no doc changes, no index churn."""
+    legacy_collection.create_index([("namespace", 1), ("key", 1)], unique=True)
+    now = datetime.now()
+    legacy_collection.insert_many(
+        [
+            {
+                "namespace": ["users", "alice"],
+                "key": "k",
+                "value": {"v": 1},
+                "created_at": now,
+                "updated_at": now,
+            },
+            {
+                "namespace": ["a", "b"],
+                "key": "k",
+                "value": {"v": 2},
+                "created_at": now,
+                "updated_at": now,
+            },
+        ]
+    )
+
+    MongoDBStore(legacy_collection)
+
+    docs_after_first = sorted(
+        (
+            (d["namespace_str"], d["key"], d["value"])
+            for d in legacy_collection.find({})
+        ),
+    )
+    indexes_after_first = sorted(
+        (idx["name"], dict(idx["key"]), idx.get("unique", False))
+        for idx in legacy_collection.list_indexes()
+    )
+
+    MongoDBStore(legacy_collection)
+
+    docs_after_second = sorted(
+        (
+            (d["namespace_str"], d["key"], d["value"])
+            for d in legacy_collection.find({})
+        ),
+    )
+    indexes_after_second = sorted(
+        (idx["name"], dict(idx["key"]), idx.get("unique", False))
+        for idx in legacy_collection.list_indexes()
+    )
+
+    assert docs_after_first == docs_after_second
+    assert indexes_after_first == indexes_after_second


### PR DESCRIPTION
[INTPYTHON-957](https://jira.mongodb.org/browse/INTPYTHON-957)

## Summary

Adds regression coverage for the index-upgrade path in `MongoDBStore.__init__` introduced by [INTPYTHON-948 / #375](https://github.com/langchain-ai/langchain-mongodb/pull/375). That PR replaced a unique compound index on the `namespace` array (which produced multikey collisions) with a unique compound index on a denormalized `namespace_str` field, and added in-place migration logic for collections created under the old schema. The migration logic itself was untested — the existing `store` fixture wipes the collection and drops all indexes before each test, so no test exercised the upgrade branch. This PR closes that gap.

## Changes in this PR

Three new tests in `libs/langgraph-store-mongodb/tests/unit_tests/test_store.py`, plus a dedicated `legacy_collection` fixture (using its own `long_term_memory_legacy` collection so it can't perturb or be perturbed by the shared `store` fixture):

- **`test_upgrade_from_legacy_index`** — sets up a collection with the legacy unique `(namespace, key)` multikey index and pre-existing documents lacking `namespace_str`, then constructs `MongoDBStore` and asserts: every document is backfilled with `namespace_str = "/".join(namespace)`, the legacy index is dropped, a unique `(namespace_str, key)` index now exists, reads return the original values, and a `put` against a legacy `(namespace, key)` updates rather than inserts.
- **`test_upgrade_with_conflicting_non_unique_index`** — creates a non-unique `(namespace_str, key)` index up front, then asserts init drops it and replaces it with the unique variant. Covers the explicit branch at `base.py:218–224`.
- **`test_upgrade_idempotent`** — re-initializes `MongoDBStore` against an already-migrated collection and asserts no document or index changes between the two initializations.

No production code is changed.

## Test Plan

- All three new tests pass against a local Atlas instance: `uv run pytest tests/unit_tests/test_store.py -k upgrade`.
- Full `test_store.py` (12 tests, 9 pre-existing + 3 new) passes: `uv run pytest tests/unit_tests/test_store.py`.
- One side-effect surfaced during test development, flagged here for visibility (not addressed in this PR): `base.py:230` drops the legacy index by key spec, which pymongo resolves to the auto-generated name `namespace_1_key_1`. Collections whose legacy index was created with a custom name would not match, and the drop would raise `OperationFailure: index not found`. Real-world risk is low because PR #375 created the index without a custom name, but worth a separate ticket if we want defense-in-depth.

## Checklist

### Checklist for Author

- [ ] Did you update the changelog (if necessary)? — N/A, tests only
- [x] Is the intention of the code captured in relevant tests? — these tests *are* the intent
- [ ] If there are new TODOs, has a related JIRA ticket been created?
- [ ] Has a MongoDB Employee run [the patch build of this PR](https://github.com/mongodb-labs/ai-ml-pipeline-testing?tab=readme-ov-file#running-a-patch-build-of-a-given-pr)?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
