### PR TITLE
[INTPYTHON-961] Reject MQL operator keys in filter dicts to prevent query injection

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/CHANGELOG.md
+++ b/libs/langgraph-checkpoint-mongodb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ---
 
+## Changes in version 0.3.2 (Unreleased)
+
+- Fixes a NoSQL operator injection vulnerability (GHSA-533j-2v4q-mw5h) in `MongoDBSaver.list()` and `alist()`. Filter dict keys are now validated recursively; any key starting with `$` raises a `ValueError`, preventing callers from injecting MQL operators such as `$exists`, `$ne`, or `$where` into the query.
+
 ## Changes in version 0.3.1 (2026/01/22)
 - Fixes issue #287 to migrate checkpoint data created with v<0.2.2 with a migration script: [migrate_checkpoints_to_typed_metadata.py](./scripts/migrate_checkpoints_to_typed_metadata.py).
 - Fixes issue #299 to ensure TTL indexes are always created on initialization of MongoDBSaver if enabled.

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/saver.py
@@ -23,7 +23,7 @@ from pymongo import ASCENDING, MongoClient, UpdateOne
 from pymongo.collection import Collection
 from pymongo.database import Database as MongoDatabase
 
-from .utils import DRIVER_METADATA, dumps_metadata, loads_metadata
+from .utils import DRIVER_METADATA, _validate_filter, dumps_metadata, loads_metadata
 
 
 def _create_saver_indexes(
@@ -323,6 +323,7 @@ class MongoDBSaver(BaseCheckpointSaver):
                 query["checkpoint_ns"] = config["configurable"]["checkpoint_ns"]
 
         if filter:
+            _validate_filter(filter)
             for key, value in filter.items():
                 query[f"metadata.{key}"] = dumps_metadata(self.serde, value)
 

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
@@ -43,6 +43,16 @@ def loads_metadata(
         return serde.loads_typed(metadata)
 
 
+def _validate_filter(filter_dict: dict) -> None:  # type: ignore[type-arg]
+    for key, value in filter_dict.items():
+        if not isinstance(key, str) or key.startswith("$"):
+            raise ValueError(
+                f"Invalid filter key '{key}': MongoDB operator keys are not allowed."
+            )
+        if isinstance(value, dict):
+            _validate_filter(value)
+
+
 def dumps_metadata(
     serde: SerializerProtocol,
     metadata: Union[CheckpointMetadata, Any],

--- a/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
+++ b/libs/langgraph-checkpoint-mongodb/langgraph/checkpoint/mongodb/utils.py
@@ -43,7 +43,7 @@ def loads_metadata(
         return serde.loads_typed(metadata)
 
 
-def _validate_filter(filter_dict: dict) -> None:  # type: ignore[type-arg]
+def _validate_filter(filter_dict: dict[str, Any]) -> None:
     for key, value in filter_dict.items():
         if not isinstance(key, str) or key.startswith("$"):
             raise ValueError(

--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_async.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_async.py
@@ -112,3 +112,10 @@ async def test_null_chars(input_data: dict[str, Any], saver: MongoDBSaver) -> No
             {null_str: "my_value"},  # type: ignore
             {},
         )
+
+
+async def test_alist_rejects_mql_operator_keys(saver: MongoDBSaver) -> None:
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [c async for c in saver.alist(None, filter={"status": {"$regex": ".*"}})]
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [c async for c in saver.alist(None, filter={"$where": "1==1"})]

--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_async.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_async.py
@@ -115,7 +115,69 @@ async def test_null_chars(input_data: dict[str, Any], saver: MongoDBSaver) -> No
 
 
 async def test_alist_rejects_mql_operator_keys(saver: MongoDBSaver) -> None:
+    # nested operator value — $exists bypass leaks all checkpoints
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [c async for c in saver.alist(None, filter={"user_id": {"$exists": True}})]
+    # $ne leaks other tenants' checkpoints
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [c async for c in saver.alist(None, filter={"user_id": {"$ne": "alice"}})]
+    # $gt bypasses numeric metadata filter
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [c async for c in saver.alist(None, filter={"step": {"$gt": 0}})]
+    # $in enumerates across tenants
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [
+            c
+            async for c in saver.alist(
+                None, filter={"user_id": {"$in": ["alice", "bob"]}}
+            )
+        ]
+    # $regex pattern match
     with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         [c async for c in saver.alist(None, filter={"status": {"$regex": ".*"}})]
+    # top-level $where injection
     with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         [c async for c in saver.alist(None, filter={"$where": "1==1"})]
+    # top-level $or injection
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        [c async for c in saver.alist(None, filter={"$or": [{"source": "loop"}]})]
+
+
+async def test_alist_filter_normal_behavior(
+    input_data: dict[str, Any], saver: MongoDBSaver
+) -> None:
+    """Safe filters — including nested dicts with non-$ keys — work unchanged after the patch."""
+    await saver.aput(
+        input_data["config_1"], input_data["chkpnt_1"], input_data["metadata_1"], {}
+    )
+    await saver.aput(
+        input_data["config_2"], input_data["chkpnt_2"], input_data["metadata_2"], {}
+    )
+    await saver.aput(
+        input_data["config_3"], input_data["chkpnt_3"], input_data["metadata_3"], {}
+    )
+
+    # empty filter: returns all 3 checkpoints
+    assert len([c async for c in saver.alist(None, filter={})]) == 3
+
+    # string scalar filter
+    results = [c async for c in saver.alist(None, filter={"source": "input"})]
+    assert len(results) == 1 and results[0].metadata["source"] == "input"
+
+    # numeric scalar filter
+    results = [c async for c in saver.alist(None, filter={"step": 1})]
+    assert len(results) == 1 and results[0].metadata["step"] == 1
+
+    # multiple scalar filters (AND)
+    results = [c async for c in saver.alist(None, filter={"source": "loop", "step": 1})]
+    assert len(results) == 1
+
+    # no match returns empty
+    results = [
+        c async for c in saver.alist(None, filter={"source": "update", "step": 1})
+    ]
+    assert len(results) == 0
+
+    # nested dict with safe (non-$) keys is allowed — not rejected as injection
+    results = [c async for c in saver.alist(None, filter={"writes": {"foo": "bar"}})]
+    assert len(results) == 1 and results[0].metadata["writes"] == {"foo": "bar"}

--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
@@ -253,3 +253,11 @@ def test_init_creates_indexes() -> None:
 
     db.drop_collection(checkpoint_coll)
     db.drop_collection(writes_coll)
+
+
+def test_list_rejects_mql_operator_keys() -> None:
+    with MongoDBSaver.from_conn_string(MONGODB_URI) as saver:
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"status": {"$regex": ".*"}}))
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"$where": "1==1"}))

--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
@@ -257,7 +257,65 @@ def test_init_creates_indexes() -> None:
 
 def test_list_rejects_mql_operator_keys() -> None:
     with MongoDBSaver.from_conn_string(MONGODB_URI) as saver:
+        # nested operator value — $exists bypass leaks all checkpoints
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"user_id": {"$exists": True}}))
+        # $ne leaks other tenants' checkpoints
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"user_id": {"$ne": "alice"}}))
+        # $gt bypasses numeric metadata filter
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"step": {"$gt": 0}}))
+        # $in enumerates across tenants
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"user_id": {"$in": ["alice", "bob"]}}))
+        # $regex pattern match
         with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
             list(saver.list(None, filter={"status": {"$regex": ".*"}}))
+        # top-level $where injection
         with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
             list(saver.list(None, filter={"$where": "1==1"}))
+        # top-level $or injection
+        with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+            list(saver.list(None, filter={"$or": [{"source": "loop"}]}))
+
+
+def test_list_filter_normal_behavior(input_data: dict[str, Any]) -> None:
+    """Safe filters — including nested dicts with non-$ keys — work unchanged after the patch."""
+    clxn_name = "filter_normal_behavior"
+    with MongoDBSaver.from_conn_string(MONGODB_URI, DB_NAME, clxn_name) as saver:
+        saver.put(
+            input_data["config_1"], input_data["chkpnt_1"], input_data["metadata_1"], {}
+        )
+        saver.put(
+            input_data["config_2"], input_data["chkpnt_2"], input_data["metadata_2"], {}
+        )
+        saver.put(
+            input_data["config_3"], input_data["chkpnt_3"], input_data["metadata_3"], {}
+        )
+
+        # empty filter: returns all 3 checkpoints
+        assert len(list(saver.list(None, filter={}))) == 3
+
+        # string scalar filter
+        results = list(saver.list(None, filter={"source": "input"}))
+        assert len(results) == 1 and results[0].metadata["source"] == "input"
+
+        # numeric scalar filter
+        results = list(saver.list(None, filter={"step": 1}))
+        assert len(results) == 1 and results[0].metadata["step"] == 1
+
+        # multiple scalar filters (AND)
+        results = list(saver.list(None, filter={"source": "loop", "step": 1}))
+        assert len(results) == 1
+
+        # no match returns empty
+        results = list(saver.list(None, filter={"source": "update", "step": 1}))
+        assert len(results) == 0
+
+        # nested dict with safe (non-$) keys is allowed — not rejected as injection
+        results = list(saver.list(None, filter={"writes": {"foo": "bar"}}))
+        assert len(results) == 1 and results[0].metadata["writes"] == {"foo": "bar"}
+
+        saver.checkpoint_collection.drop()
+        saver.writes_collection.drop()

--- a/libs/langgraph-store-mongodb/CHANGELOG.md
+++ b/libs/langgraph-store-mongodb/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Changes in version 0.2.1 (Unreleased)
 
+- Fixes a NoSQL operator injection vulnerability (GHSA-533j-2v4q-mw5h) in `MongoDBStore.search()` and `asearch()`. Filter dict keys are now validated recursively; any key starting with `$` raises a `ValueError`, preventing callers from injecting MQL operators such as `$exists`, `$ne`, or `$where` into the query.
 - Fixes duplicate-key collisions when two items share a namespace component and the same key (INTPYTHON-948). The unique index is now created on a denormalized `namespace_str` field (e.g. `"users/alice/preferences"`) instead of the `namespace` array, which was creating a multikey index in MongoDB. **Operational note:** this release is not safe for mixed-version deployments. Old clients that write documents without `namespace_str` will create documents that new clients cannot retrieve. Upgrade all writers and readers together; do not run old and new versions of the store concurrently against the same collection.
 
 ## Changes in version 0.2.0 (2026/01/15)

--- a/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
+++ b/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
@@ -699,6 +699,11 @@ class MongoDBStore(BaseStore):
         if filter:
             if any(f.startswith("value") for f in filter):
                 raise ValueError("filters should be specified without `value`")
+            if any(isinstance(v, dict) for v in filter.values()):
+                raise ValueError(
+                    "filter values must be scalars (str, int, float, bool, None); "
+                    "dict values allow MQL operator injection"
+                )
 
         if query is None:
             # Case 1. $match namespace and filter

--- a/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
+++ b/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
@@ -46,7 +46,7 @@ from langgraph.store.mongodb.utils import DRIVER_METADATA
 logger = logging.getLogger(__name__)
 
 
-def _validate_filter(filter_dict: dict) -> None:  # type: ignore[type-arg]
+def _validate_filter(filter_dict: dict[str, Any]) -> None:
     for key, value in filter_dict.items():
         if not isinstance(key, str) or key.startswith("$"):
             raise ValueError(

--- a/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
+++ b/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
@@ -46,6 +46,16 @@ from langgraph.store.mongodb.utils import DRIVER_METADATA
 logger = logging.getLogger(__name__)
 
 
+def _validate_filter(filter_dict: dict) -> None:  # type: ignore[type-arg]
+    for key, value in filter_dict.items():
+        if not isinstance(key, str) or key.startswith("$"):
+            raise ValueError(
+                f"Invalid filter key '{key}': MongoDB operator keys are not allowed."
+            )
+        if isinstance(value, dict):
+            _validate_filter(value)
+
+
 class VectorIndexConfig(IndexConfig, total=False):
     """Configuration for a MongoDB Atlas Vector Index providing semantic search.
 
@@ -699,11 +709,7 @@ class MongoDBStore(BaseStore):
         if filter:
             if any(f.startswith("value") for f in filter):
                 raise ValueError("filters should be specified without `value`")
-            if any(isinstance(v, dict) for v in filter.values()):
-                raise ValueError(
-                    "filter values must be scalars (str, int, float, bool, None); "
-                    "dict values allow MQL operator injection"
-                )
+            _validate_filter(filter)
 
         if query is None:
             # Case 1. $match namespace and filter

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
@@ -395,9 +395,11 @@ def test_search_basic(store: MongoDBStore) -> None:
     assert len(result) == 1
 
 
-def test_search_rejects_dict_filter_values(store: MongoDBStore) -> None:
-    with pytest.raises(ValueError, match="filter values must be scalars"):
+def test_search_rejects_mql_operator_keys(store: MongoDBStore) -> None:
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         store.search(("a",), filter={"status": {"$regex": ".*"}})
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        store.search(("a",), filter={"$where": "sleep(1000)"})
 
 
 # ---------------------------------------------------------------------------

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
@@ -395,6 +395,11 @@ def test_search_basic(store: MongoDBStore) -> None:
     assert len(result) == 1
 
 
+def test_search_rejects_dict_filter_values(store: MongoDBStore) -> None:
+    with pytest.raises(ValueError, match="filter values must be scalars"):
+        store.search(("a",), filter={"status": {"$regex": ".*"}})
+
+
 # ---------------------------------------------------------------------------
 # INTPYTHON-957: upgrade path from the legacy (namespace, key) multikey index
 # to the new (namespace_str, key) unique index, plus namespace_str backfill.

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store.py
@@ -396,10 +396,72 @@ def test_search_basic(store: MongoDBStore) -> None:
 
 
 def test_search_rejects_mql_operator_keys(store: MongoDBStore) -> None:
+    # nested operator value — $exists bypass leaks all docs
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        store.search(("a",), filter={"user_id": {"$exists": True}})
+    # $ne leaks other tenants' data
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        store.search(("a",), filter={"user_id": {"$ne": "alice"}})
+    # $gt bypasses numeric filter
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        store.search(("a",), filter={"step": {"$gt": 0}})
+    # $in enumerates across tenants
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        store.search(("a",), filter={"user_id": {"$in": ["alice", "bob"]}})
+    # $regex pattern match
     with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         store.search(("a",), filter={"status": {"$regex": ".*"}})
+    # top-level $where injection
     with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         store.search(("a",), filter={"$where": "sleep(1000)"})
+    # top-level $or injection
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        store.search(("a",), filter={"$or": [{"user_id": "alice"}]})
+
+
+def test_search_filter_normal_behavior(store: MongoDBStore) -> None:
+    """Safe filters — including nested dicts with non-$ keys — work unchanged after the patch."""
+    ns = ("users", "filter-test")
+    store.put(ns, "alice-0", {"user_id": "alice", "step": 0})
+    store.put(ns, "alice-1", {"user_id": "alice", "step": 1})
+    store.put(ns, "bob-0", {"user_id": "bob", "step": 0})
+    store.put(ns, "bob-1", {"user_id": "bob", "step": 1})
+
+    # no filter: returns all items in namespace
+    assert len(store.search(ns)) == 4
+
+    # string scalar filter: only alice's items
+    results = store.search(ns, filter={"user_id": "alice"})
+    assert len(results) == 2
+    assert all(r.value["user_id"] == "alice" for r in results)
+
+    # numeric scalar filter: step==0 across both users
+    results = store.search(ns, filter={"step": 0})
+    assert len(results) == 2
+    assert all(r.value["step"] == 0 for r in results)
+
+    # multiple scalar filters (AND): alice AND step==1
+    results = store.search(ns, filter={"user_id": "alice", "step": 1})
+    assert len(results) == 1
+    assert results[0].value["user_id"] == "alice" and results[0].value["step"] == 1
+
+    # no match returns empty list
+    results = store.search(ns, filter={"user_id": "charlie"})
+    assert len(results) == 0
+
+    # namespace isolation: different namespace returns empty
+    results = store.search(("other", "ns"), filter={"user_id": "alice"})
+    assert len(results) == 0
+
+    # nested dict with safe (non-$) keys is allowed — not rejected as injection
+    store.put(
+        ns,
+        "alice-meta",
+        {"user_id": "alice", "meta": {"source": "api", "version": "v1"}},
+    )
+    results = store.search(ns, filter={"meta": {"source": "api", "version": "v1"}})
+    assert len(results) == 1
+    assert results[0].value["user_id"] == "alice"
 
 
 # ---------------------------------------------------------------------------

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store_async.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store_async.py
@@ -354,7 +354,71 @@ async def test_asearch_basic(store: MongoDBStore) -> None:
 
 
 async def test_asearch_rejects_mql_operator_keys(store: MongoDBStore) -> None:
+    # nested operator value — $exists bypass leaks all docs
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        await store.asearch(("a",), filter={"user_id": {"$exists": True}})
+    # $ne leaks other tenants' data
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        await store.asearch(("a",), filter={"user_id": {"$ne": "alice"}})
+    # $gt bypasses numeric filter
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        await store.asearch(("a",), filter={"step": {"$gt": 0}})
+    # $in enumerates across tenants
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        await store.asearch(("a",), filter={"user_id": {"$in": ["alice", "bob"]}})
+    # $regex pattern match
     with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         await store.asearch(("a",), filter={"status": {"$regex": ".*"}})
+    # top-level $where injection
     with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         await store.asearch(("a",), filter={"$where": "1==1"})
+    # top-level $or injection
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        await store.asearch(("a",), filter={"$or": [{"user_id": "alice"}]})
+
+
+async def test_asearch_filter_normal_behavior(store: MongoDBStore) -> None:
+    """Safe filters — including nested dicts with non-$ keys — work unchanged after the patch."""
+    ns = ("users", "async-filter-test")
+    await store.aput(ns, "alice-0", {"user_id": "alice", "step": 0})
+    await store.aput(ns, "alice-1", {"user_id": "alice", "step": 1})
+    await store.aput(ns, "bob-0", {"user_id": "bob", "step": 0})
+    await store.aput(ns, "bob-1", {"user_id": "bob", "step": 1})
+
+    # no filter: returns all items in namespace
+    assert len(await store.asearch(ns)) == 4
+
+    # string scalar filter: only alice's items
+    results = await store.asearch(ns, filter={"user_id": "alice"})
+    assert len(results) == 2
+    assert all(r.value["user_id"] == "alice" for r in results)
+
+    # numeric scalar filter: step==0 across both users
+    results = await store.asearch(ns, filter={"step": 0})
+    assert len(results) == 2
+    assert all(r.value["step"] == 0 for r in results)
+
+    # multiple scalar filters (AND): alice AND step==1
+    results = await store.asearch(ns, filter={"user_id": "alice", "step": 1})
+    assert len(results) == 1
+    assert results[0].value["user_id"] == "alice" and results[0].value["step"] == 1
+
+    # no match returns empty list
+    results = await store.asearch(ns, filter={"user_id": "charlie"})
+    assert len(results) == 0
+
+    # namespace isolation: different namespace returns empty
+    results = await store.asearch(("other", "async-ns"), filter={"user_id": "alice"})
+    assert len(results) == 0
+
+    # nested dict with safe (non-$) keys is allowed — not rejected as injection
+    await store.aput(
+        ns,
+        "alice-meta",
+        {"user_id": "alice", "meta": {"source": "api", "version": "v1"}},
+    )
+    results = await store.asearch(
+        ns, filter={"meta": {"source": "api", "version": "v1"}}
+    )
+    assert len(results) == 1
+    assert results[0].value["user_id"] == "alice"

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store_async.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store_async.py
@@ -353,6 +353,8 @@ async def test_asearch_basic(store: MongoDBStore) -> None:
     assert len(result) == 1
 
 
-async def test_asearch_rejects_dict_filter_values(store: MongoDBStore) -> None:
-    with pytest.raises(ValueError, match="filter values must be scalars"):
+async def test_asearch_rejects_mql_operator_keys(store: MongoDBStore) -> None:
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
         await store.asearch(("a",), filter={"status": {"$regex": ".*"}})
+    with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
+        await store.asearch(("a",), filter={"$where": "1==1"})

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_store_async.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_store_async.py
@@ -3,6 +3,7 @@ import os
 from collections.abc import AsyncGenerator
 from datetime import datetime
 
+import pytest
 import pytest_asyncio
 from langgraph.store.base import (
     GetOp,
@@ -350,3 +351,8 @@ async def test_asearch_basic(store: MongoDBStore) -> None:
     await store.aput(namespace=namespace, key="id_foo", value={"data": "value_foo"})
     result = await store.asearch(namespace, filter={"data": "value_foo"})
     assert len(result) == 1
+
+
+async def test_asearch_rejects_dict_filter_values(store: MongoDBStore) -> None:
+    with pytest.raises(ValueError, match="filter values must be scalars"):
+        await store.asearch(("a",), filter={"status": {"$regex": ".*"}})


### PR DESCRIPTION
[INTPYTHON-961](https://jira.mongodb.org/browse/INTPYTHON-961)