### PR TITLE
INTPYTHON-981 Fix AutoEmbeddings index configuration

### DIFF
--- a/libs/langgraph-store-mongodb/CHANGELOG.md
+++ b/libs/langgraph-store-mongodb/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## Changes in version 0.4.0 (XXXX/XX/XX)
 
+- Fix `create_vector_index_config` so `AutoEmbeddings` indexes can be configured
+  without explicitly passing dimensions or similarity.
 - Add native reranking (`$rerank`) support to `MongoDBStore.search()`. Pass a
   `RerankConfig` to the `MongoDBStore` constructor to enable reranking of vector
   search results using the Voyage AI reranker. Requires MongoDB Atlas 8.3+,

--- a/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
+++ b/libs/langgraph-store-mongodb/langgraph/store/mongodb/base.py
@@ -119,7 +119,8 @@ class VectorIndexConfig(IndexConfig, total=False):
     It is designed to have one vector per document.
 
     NOTE: If using AutoEmbeddings, the vectors are not explicitly stored in the Collection.
-    Set dims to -1, relevance_score_fn to None.
+    The factory function automatically configures dimensions and similarity for
+    auto-embedding indexes.
     The embedding_key will not store vectors. Instead, it will be the texts to be embedded.
     """
 
@@ -139,27 +140,45 @@ class VectorIndexConfig(IndexConfig, total=False):
 
 
 def create_vector_index_config(
-    dims: int | None,
-    embed: Union[Embeddings, EmbeddingsFunc, AEmbeddingsFunc, str],
+    dims: int | None = None,
+    embed: Optional[Union[Embeddings, EmbeddingsFunc, AEmbeddingsFunc, str]] = None,
     fields: Optional[list[str]] = None,
     name: str = "vector_index",
-    relevance_score_fn: Literal["euclidean", "cosine", "dotProduct", None] = "cosine",
+    relevance_score_fn: Literal["euclidean", "cosine", "dotProduct", None] = None,
     embedding_key: str | None = "embedding",
     filters: Optional[list[str]] = None,
 ) -> VectorIndexConfig:
     """Factory function creates a VectorIndexConfig instance with sensible defaults.
 
     Args:
-        dims: Dimensions of the embedding vectors.
+        dims: Dimensions of the embedding vectors. Required unless using
+            AutoEmbeddings.
         embed: Embedding model.
         fields: Field to extract text from for embedding generation (list of length 1).
         name: Arbitrary name to give to the index in Atlas.
         relevance_score_fn: Function used to establish similarity of vectors.
+            Defaults to cosine for manual embeddings and must be omitted for
+            AutoEmbeddings.
         embedding_key: Name of the field used in the collection to store vectors.
         filters: List of (possibly nested) fields to index allowing filtering.
 
     Returns: VectorIndexConfig to be passed to MongoDBStore constructor.
     """
+
+    if embed is None:
+        raise ValueError("embed is required.")
+
+    if isinstance(embed, AutoEmbeddings):
+        if dims not in (None, -1):
+            raise ValueError("dimensions cannot be set when using AutoEmbeddings.")
+        if relevance_score_fn is not None:
+            raise ValueError("similarity cannot be set when using AutoEmbeddings.")
+        dims = -1
+    else:
+        if dims is None:
+            raise ValueError("dims is required when using manual embeddings.")
+        if relevance_score_fn is None:
+            relevance_score_fn = "cosine"
 
     MongoDBStore.ensure_index_filters(filters)
     if filters and "namespace_prefix" not in filters:

--- a/libs/langgraph-store-mongodb/tests/integration_tests/test_autoembedded_index.py
+++ b/libs/langgraph-store-mongodb/tests/integration_tests/test_autoembedded_index.py
@@ -31,8 +31,6 @@ COLLECTION_NAME = "semantic_search_autoembedded"
 INDEX_NAME = "auto_vector_index"
 TIMEOUT, INTERVAL = 60, 1  # timeout to index new data
 
-DIMENSIONS = -1
-
 
 def wait_until(
     predicate: Callable, timeout: int = TIMEOUT, interval: int = INTERVAL
@@ -71,8 +69,6 @@ def test_filters(collection: Collection) -> None:
 
     index_config = create_vector_index_config(
         name=INDEX_NAME,
-        dims=DIMENSIONS,
-        relevance_score_fn=None,
         fields=["product"],
         embed=AutoEmbeddings(model="voyage-4"),  # embedding
         filters=["metadata.available"],

--- a/libs/langgraph-store-mongodb/tests/unit_tests/test_index_config.py
+++ b/libs/langgraph-store-mongodb/tests/unit_tests/test_index_config.py
@@ -1,0 +1,42 @@
+import pytest
+from langchain_mongodb.embeddings import AutoEmbeddings
+
+from langgraph.store.mongodb import create_vector_index_config
+
+
+def test_create_vector_index_config_with_autoembeddings() -> None:
+    config = create_vector_index_config(
+        embed=AutoEmbeddings("voyage-4"),
+        fields=["question"],
+    )
+
+    assert config["dims"] == -1
+    assert config["relevance_score_fn"] is None
+
+
+def test_create_vector_index_config_with_manual_embeddings() -> None:
+    config = create_vector_index_config(1536, "openai:text-embedding-3-small")
+
+    assert config["dims"] == 1536
+    assert config["relevance_score_fn"] == "cosine"
+
+
+def test_create_vector_index_config_requires_manual_embedding_dimensions() -> None:
+    with pytest.raises(ValueError, match="dims is required"):
+        create_vector_index_config(embed="openai:text-embedding-3-small")
+
+
+def test_create_vector_index_config_rejects_autoembedding_dimensions() -> None:
+    with pytest.raises(ValueError, match="dimensions"):
+        create_vector_index_config(
+            dims=1024,
+            embed=AutoEmbeddings("voyage-4"),
+        )
+
+
+def test_create_vector_index_config_rejects_autoembedding_similarity() -> None:
+    with pytest.raises(ValueError, match="similarity"):
+        create_vector_index_config(
+            embed=AutoEmbeddings("voyage-4"),
+            relevance_score_fn="cosine",
+        )


### PR DESCRIPTION
[INTPYTHON-981]

## Summary

Fix vector index configuration when using `AutoEmbeddings` without explicitly providing dimensions or similarity.

## Changes in this PR

- Infer the required AutoEmbeddings index settings.
- Preserve existing defaults for manual embeddings.
- Add regression tests and update the AutoEmbeddings integration test.
- Update the changelog and docstring.

## Test Plan

- Added five unit tests covering AutoEmbeddings and manual embeddings.
- Unit tests, mypy, Ruff, and pre-commit checks pass.
- The integration test was not run locally because MongoDB Community with Search was unavailable.
