### PR TITLE
INTPYTHON-1060 fix(deepagents-vfs): bound the fulltext branch of hybrid grep's $rankFusion

### DIFF
--- a/libs/langchain-mongodb-deepagents-vfs/langchain_mongodb_deepagents_vfs/search.py
+++ b/libs/langchain-mongodb-deepagents-vfs/langchain_mongodb_deepagents_vfs/search.py
@@ -271,11 +271,18 @@ class SearchRouter:
         pre_filter: dict[str, Any] = {"$and": path_filter} if path_filter else {}
 
         if query_vector is not None:
+            # Both branches feed the same combination step, so both need a
+            # comparable bound: $vectorSearch already caps itself via its own
+            # limit/numCandidates fields, but $search has no such built-in cap
+            # — without an explicit $limit here, the fulltext branch could
+            # rank an unbounded number of candidates before the single $limit
+            # trailing the whole $rankFusion ever gets a chance to trim it.
+            top_k = self._grep_limit * 2
             vs_stage = vector_search_stage(
                 query_vector,
                 "embedding",
                 "vector_search_embedding",
-                top_k=self._grep_limit * 2,
+                top_k=top_k,
                 # $vectorSearch filter only supports comparison operators ($eq, $in, etc.),
                 # not $regex — apply path/glob filtering as a $match stage after the ANN search
                 filter=None,
@@ -297,6 +304,7 @@ class SearchRouter:
                                             },
                                         }
                                     },
+                                    {"$limit": top_k},
                                     *([{"$match": pre_filter}] if pre_filter else []),
                                 ],
                                 "vector": [

--- a/libs/langchain-mongodb-deepagents-vfs/tests/unit_tests/test_search_router.py
+++ b/libs/langchain-mongodb-deepagents-vfs/tests/unit_tests/test_search_router.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import MagicMock
+
 import pytest
 
 from langchain_mongodb_deepagents_vfs.dtypes import GlobResult, GrepResult, LsResult
@@ -212,3 +214,36 @@ class TestSearchRouterGrep:
         assert result.matches
         for m in result.matches:
             assert set(m) == {"path", "line", "text"}
+
+
+@pytest.mark.unit
+class TestGrepHybridPipelineShape:
+    """The $rankFusion pipeline's two branches must be bounded the same way.
+
+    vector_search_stage() already caps the vector branch via the
+    $vectorSearch stage's own numCandidates/limit fields. The fulltext
+    branch is hand-built rather than going through the text_search_stage()
+    helper this same module already uses for the no-vector fallback, and
+    without its own $limit it can rank an unbounded candidate set before
+    the single $limit trailing the whole $rankFusion ever trims it.
+    """
+
+    def _captured_pipeline(self, mock_embedder, **grep_kwargs):
+        col = MagicMock()
+        col.aggregate.return_value = []
+        router = SearchRouter(col, mock_embedder, atlas_available=True)
+        router.grep("query", **grep_kwargs)
+        (pipeline,), _ = col.aggregate.call_args
+        return pipeline
+
+    def test_fulltext_branch_has_its_own_limit(self, mock_embedder):
+        pipeline = self._captured_pipeline(mock_embedder)
+        fulltext_stages = pipeline[0]["$rankFusion"]["input"]["pipelines"]["fulltext"]
+        assert any("$limit" in stage for stage in fulltext_stages)
+
+    def test_fulltext_limit_matches_vector_branch_top_k(self, mock_embedder):
+        pipeline = self._captured_pipeline(mock_embedder)
+        stages = pipeline[0]["$rankFusion"]["input"]["pipelines"]
+        vector_top_k = stages["vector"][0]["$vectorSearch"]["limit"]
+        fulltext_limit = next(s["$limit"] for s in stages["fulltext"] if "$limit" in s)
+        assert fulltext_limit == vector_top_k


### PR DESCRIPTION
## Summary
- `SearchRouter._grep_hybrid`'s `$rankFusion` combines a vector branch and a fulltext branch, but only the vector branch was actually bounded: `vector_search_stage()` bakes `limit`/`numCandidates` directly into the `$vectorSearch` stage itself, while the hand-rolled fulltext branch (`$search` + optional `$match`) had no `$limit` of its own — only a single `$limit` trailing the entire `$rankFusion` combination.
- A common search term against a large collection let the fulltext branch rank an unbounded candidate set before that trailing limit ever got a chance to trim it, and the two branches feeding the same RRF combination were sized asymmetrically.
- Adds an explicit `{"$limit": top_k}` to the fulltext branch, matching the vector branch's `top_k` (`grep_limit * 2`), so both branches are bounded the same way before combination.

Kept the existing hand-rolled `$search` stage rather than switching to the `text_search_stage()` helper already used elsewhere in this file — that helper defaults to emitting an extra `$set: {score: ...}` stage, which is wasted work here since `$rankFusion` combines by rank order, not raw `$search` score, and nothing downstream reads a `score` field.

Note: this does not address the separate, larger question of whether `path`/`glob` scoping should be pushed into the `$search`/`$vectorSearch` stages themselves rather than applied as a post-search `$match` — that's tracked separately (see `jira_grep_hybrid.txt` for the fuller writeup) as a decision that needs verifying Atlas Search's `compound.filter` support, not something to bundle into this minimal fix.

## Test plan
- [x] Added `TestGrepHybridPipelineShape` in `test_search_router.py`: captures the constructed `$rankFusion` pipeline via a mocked collection and asserts the fulltext branch has its own `$limit`, matching the vector branch's `top_k`.
- [x] `uv run pytest tests/unit_tests tests/integration_tests` — all pass (156 tests).
- [x] `just lint` / `just typing` — clean.