### PR TITLE
INTPYTHON-1073 Document PyPI Trusted Publishing setup for a new library's first release

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
 
 - Create a PR to bump the version and update the changelog, including today's date.
   Bump the minor version for new features, patch for a bug fix.
+- If this is the first release of any new library, see TRUSTED_PUBLISHING.md.
 
 - Merge the PR.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,7 @@
 
 - Create a PR to bump the version and update the changelog, including today's date.
   Bump the minor version for new features, patch for a bug fix.
-- If this is the first release of any new library, see TRUSTED_PUBLISHING.md.
+- If this is the first release of any new library, see [TRUSTED_PUBLISHING.md](TRUSTED_PUBLISHING.md).
 
 - Merge the PR.
 

--- a/TRUSTED_PUBLISHING.md
+++ b/TRUSTED_PUBLISHING.md
@@ -1,0 +1,100 @@
+# Trusted Publishing Setup (first release of a new library)
+
+One-time setup required **before the first release of any new library** in this
+monorepo. Existing libraries (`langchain-mongodb`, `langgraph-checkpoint-mongodb`,
+`langgraph-store-mongodb`) are already configured — this is only for a package
+that has never been published.
+
+Companion to [`RELEASE.md`](RELEASE.md), which covers the steady-state release
+process and assumes this is already done.
+
+## Why it's needed
+
+The release workflow publishes via [PyPI Trusted Publishing][tp] (OIDC) rather
+than API tokens — there is no token to configure, and `twine` is not used
+manually. But trusted publishing cannot attach a publisher to a project that
+does not exist yet, so a brand-new package needs a **"pending publisher"**
+registered by hand first. Without it, the release run fails at the publish
+step, after a green build.
+
+[tp]: https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/
+
+## Before you start
+
+- You need an account with permission to add publishers on PyPI.
+- For a package owned by an organisation, this may need whoever owns the
+  sibling packages, who is not necessarily the person doing the release.
+
+## Register the pending publisher
+
+Go to <https://pypi.org/manage/account/publishing/>
+(Account settings → **Publishing** in the left sidebar).
+
+Scroll to **"Add a new pending publisher"** and select the **GitHub** tab.
+
+| Field | Value |
+|---|---|
+| PyPI Project Name | *the distribution name from `pyproject.toml`*, e.g. `langchain-mongodb-deepagents-vfs` |
+| Owner | `langchain-ai` |
+| Repository name | `langchain-mongodb` |
+| Workflow name | `_release.yml` |
+| Environment name | **leave empty** |
+
+Click **Add**. That is the only registration required — TestPyPI is no longer
+part of the release process.
+
+## The two easy-to-get-wrong bits
+
+### The workflow name is the file containing the publish job
+
+PyPI validates the `job_workflow_ref` OIDC claim: the workflow file containing
+**the job that requests the token**, not necessarily the workflow you dispatch.
+Here they are the same file (`_release.yml`), but if the publish job is ever
+moved into a reusable workflow, this field must name *that* file instead.
+
+Verified against [warehouse source][wh]: the claim is checked at
+`warehouse/oidc/models/github.py:156`, compared against
+`.github/workflows/{workflow_filename}` at line 242.
+
+[wh]: https://github.com/pypi/warehouse/blob/main/warehouse/oidc/models/github.py
+
+### Environment name must be blank
+
+PyPI's UI describes an environment as "optional but strongly recommended", but
+neither publish job in this repo declares an `environment:` key. If you fill
+this field in, the OIDC claim will not match and the upload is rejected.
+
+If a future change adds `environment:` to that job, the publisher config must
+be updated to match.
+
+## Gotchas
+
+- **A pending publisher does not reserve the name.** It only becomes a real
+  publisher on the first successful upload. Until then, someone else could
+  claim the name — so don't register it months ahead of releasing.
+- **Metadata is validated locally before upload.** `_release.yml` runs
+  `validate-pyproject` and `twine check --strict` in the build job, so a
+  malformed artifact fails there rather than at the PyPI upload step.
+
+## Verifying
+
+Registration does **not** create the project, so the package will still 404
+until the first successful publish. Before releasing, confirm the name is
+still unclaimed. For example:
+
+```bash
+PKG=langchain-mongodb-deepagents-vfs
+curl -s -o /dev/null -w '%{http_code}\n' https://pypi.org/pypi/$PKG/json
+# 404 = name unclaimed, pending publisher will convert on first upload
+```
+
+After the release it should return 200 and the pending publisher will have
+converted automatically — no further configuration needed for subsequent
+releases.
+
+## Note on signing
+
+Both publish steps currently set `attestations: false`, commented as a
+temporary workaround. **No Sigstore / PEP 740 attestations are produced** on
+either index. If signed releases are wanted, that flag is what to change — it
+is independent of the trusted-publishing setup above.


### PR DESCRIPTION
[INTPYTHON-1073](https://jira.mongodb.org/browse/INTPYTHON-1073)

## Summary

Adds `TRUSTED_PUBLISHING.md` documenting the one-time PyPI Trusted Publishing setup required before the **first** release of a new library, and links it from `RELEASE.md`.

`RELEASE.md` describes the steady-state release process and silently assumes trusted publishing is already configured. True for the three published libraries; not true for a new one. Trusted publishing cannot attach a publisher to a project that does not exist, so a brand-new package needs a *pending publisher* registered by hand first — otherwise the release run fails at the publish step, after a green build and after the version bump has already merged.

This surfaced while preparing the first `langchain-mongodb-deepagents-vfs` release, where the requirement was not discoverable from the repo and had to be reconstructed from PyPI docs and warehouse source.

## Changes in this PR

| File | Change |
|---|---|
| `TRUSTED_PUBLISHING.md` | new, 100 lines |
| `RELEASE.md` | one line under "Prep the Release" pointing at it |

## What the doc covers

Beyond the click-path, it records the parts that took real digging:

- **Why the workflow-name field is the file containing the *publish job***, not the workflow you dispatch. Cited to [warehouse source](https://github.com/pypi/warehouse/blob/main/warehouse/oidc/models/github.py) — the `job_workflow_ref` claim is validated at `github.py:156` and compared against `.github/workflows/{workflow_filename}` at line 242 — so a reader can verify rather than trust the doc. Also flags that this field must change if the publish job is ever moved into a reusable workflow.
- **Why the environment field must be blank.** PyPI's UI calls an environment "strongly recommended", but our publish job declares no `environment:`, and a mismatched claim is silently rejected until release time. Noted as needing revisit if `environment:` is ever added.
- **A pending publisher does not reserve the project name** until first upload.
- **A verification snippet** for confirming the name is still unclaimed before releasing.
- **`attestations: false`** in the publish step, so releases are *not* signed — independent of this setup, but easy to assume otherwise.

## Test Plan

Documentation only; no code or workflow changes.

- `Markdown Link Check`, `check-yaml`, `fix end of files`, `trim trailing whitespace` pre-commit hooks pass on both files.
- Field values cross-checked against `_release.yml` as it stands after #436: owner `langchain-ai`, repo `langchain-mongodb`, workflow `_release.yml`, environment empty.
- Written against the post-#436 state — an earlier draft covered a second TestPyPI registration; that section is removed, and there are no stale TestPyPI references.

## Checklist

### Checklist for Author

- [ ] Did you update the changelog (if necessary)?
- [ ] Is the intention of the code captured in relevant tests?
- [ ] If there are new TODOs, has a related JIRA ticket been created?
- [ ] Has a MongoDB Employee run [the patch build of this PR](https://github.com/mongodb-labs/ai-ml-pipeline-testing?tab=readme-ov-file#running-a-patch-build-of-a-given-pr)?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?

