### PR TITLE
docs: document text_key parameter in langchain-mongodb README

### DIFF
--- a/libs/langchain-mongodb/README.md
+++ b/libs/langchain-mongodb/README.md
@@ -34,6 +34,11 @@ vectorstore = MongoDBAtlasVectorSearch.from_connection_string(
     namespace=DB_NAME + "." + COLLECTION_NAME,
     embedding=OpenAIEmbeddings(model=MODEL_NAME),
     index_name=VECTOR_SEARCH_INDEX_NAME,
+    # The field in your documents that holds the page content. Defaults to
+    # "text" — if your collection stores it under a different field name
+    # (e.g. "text_clean" or "content"), set this explicitly or
+    # similarity_search will silently return no results.
+    text_key="text",
 )
 
 retrieved_docs = vectorstore.similarity_search(


### PR DESCRIPTION
Closes #211.

The MongoDBAtlasVectorSearch quickstart example in the README didn't
show the `text_key` parameter. Users whose collections store page
content under a field other than the default "text" (e.g. "text_clean")
got silent, empty `similarity_search` results with no indication of
why, as described in #211.

This adds `text_key="text"` to the example call along with a short
comment explaining what it does and why it matters.