### PR TITLE
fix: make date-only query comparisons UTC-aware in MongoDBStructuredQueryTranslator

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/retrievers/self_querying.py
+++ b/libs/langchain-mongodb/langchain_mongodb/retrievers/self_querying.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timezone
 from typing import Any, Dict, Sequence, Tuple, Union
 
 from langchain_classic.chains.query_constructor.schema import (
@@ -81,7 +82,11 @@ class MongoDBStructuredQueryTranslator(Visitor):
         """
         if isinstance(value, dict):
             if value.get("type") == "date" and "date" in value:
-                return datetime.datetime.strptime(value["date"], "%Y-%m-%d")
+                # MongoDB BSON requires timezone-aware datetimes; treat date-only
+                # strings as midnight UTC so Atlas filter comparisons work correctly.
+                return datetime.datetime.strptime(value["date"], "%Y-%m-%d").replace(
+                    tzinfo=timezone.utc
+                )
             if value.get("type") == "datetime" and "datetime" in value:
                 dt_str = value["datetime"].replace("Z", "+00:00")
                 return datetime.datetime.fromisoformat(dt_str)

--- a/libs/langchain-mongodb/tests/unit_tests/test_retrievers.py
+++ b/libs/langchain-mongodb/tests/unit_tests/test_retrievers.py
@@ -146,12 +146,15 @@ def _comparison(attribute: str, comparator: Comparator, value) -> Comparison:
 
 
 def test_visit_comparison_iso8601_date(translator):
-    """ISO8601Date dicts from the query parser are converted to datetime objects."""
+    """ISO8601Date dicts are converted to UTC-aware datetimes for BSON compatibility."""
     iso_date = {"date": "2025-01-01", "type": "date"}
     result = translator.visit_comparison(
         _comparison("timestamp", Comparator.GTE, iso_date)
     )
-    assert result == {"timestamp": {"$gte": datetime.datetime(2025, 1, 1)}}
+    expected = datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)
+    assert result == {"timestamp": {"$gte": expected}}
+    # Must be timezone-aware — naive datetimes cause incorrect Atlas filter comparisons.
+    assert result["timestamp"]["$gte"].tzinfo is not None
 
 
 def test_visit_comparison_iso8601_datetime(translator):
@@ -184,8 +187,8 @@ def test_visit_comparison_date_range(translator):
     result = translator.visit_operation(op)
     assert result == {
         "$and": [
-            {"timestamp": {"$gte": datetime.datetime(2025, 1, 1)}},
-            {"timestamp": {"$lte": datetime.datetime(2025, 12, 31)}},
+            {"timestamp": {"$gte": datetime.datetime(2025, 1, 1, tzinfo=datetime.timezone.utc)}},
+            {"timestamp": {"$lte": datetime.datetime(2025, 12, 31, tzinfo=datetime.timezone.utc)}},
         ]
     }
 


### PR DESCRIPTION
## Problem

`MongoDBStructuredQueryTranslator._convert_dict_to_datetime()` was
producing **naive** datetime objects for ISO 8601 date-only strings
(e.g. `{"date": "2025-01-01", "type": "date"}`).

MongoDB BSON / Atlas Vector Search requires timezone-aware datetimes
for filter comparisons to work correctly. Naive datetimes compare
against stored UTC timestamps incorrectly, causing date-range filters
(e.g. "Movies released before 1960") to silently return wrong results.

## Fix

Attach `tzinfo=timezone.utc` when parsing date-only strings so the
resulting datetime is midnight UTC — consistent with how the `datetime`
branch already handles the `Z` suffix.

Also updates the three existing unit tests that were asserting the old
(incorrect) naive-datetime behaviour, and adds an explicit
`tzinfo is not None` guard to make the contract explicit.

## Changes

- `libs/langchain-mongodb/langchain_mongodb/retrievers/self_querying.py` — one-line fix
- `libs/langchain-mongodb/tests/unit_tests/test_retrievers.py` — corrected assertions