### PR TITLE
fix: eliminate double MongoDB round-trip in MongoDBChatMessageHistory.messages

### DIFF
--- a/libs/langchain-mongodb/langchain_mongodb/chat_message_histories.py
+++ b/libs/langchain-mongodb/langchain_mongodb/chat_message_histories.py
@@ -138,22 +138,19 @@ class MongoDBChatMessageHistory(BaseChatMessageHistory):
             if self.history_size is None:
                 cursor = self.collection.find({self.session_id_key: self.session_id})
             else:
-                skip_count = max(
-                    0,
-                    self.collection.count_documents(
-                        {self.session_id_key: self.session_id}
-                    )
-                    - self.history_size,
+                # Use sort + limit instead of count_documents + skip so that only
+                # one round-trip to MongoDB is needed instead of two.
+                cursor = (
+                    self.collection.find({self.session_id_key: self.session_id})
+                    .sort("_id", -1)
+                    .limit(self.history_size)
                 )
-                cursor = self.collection.find(
-                    {self.session_id_key: self.session_id}, skip=skip_count
-                )
+            items = [
+                json.loads(document[self.history_key])
+                for document in reversed(list(cursor))
+            ]
         except errors.OperationFailure as error:
             logger.error(error)
-
-        if cursor:
-            items = [json.loads(document[self.history_key]) for document in cursor]
-        else:
             items = []
 
         messages = messages_from_dict(items)


### PR DESCRIPTION
## Problem

When `history_size` was set, the `messages` property made two separate
network calls to MongoDB on every read:

1. `count_documents()` to find the total number of stored messages
2. `find(..., skip=N)` to fetch only the last N messages

This doubles the latency of every `messages` access for any application
that uses `history_size`.

There was also a latent `NameError`: if `collection.find()` raised an
`OperationFailure`, the `cursor` variable was never assigned — but the
bare `if cursor:` check after the `except` block would then raise a
`NameError` instead of gracefully returning an empty list.

## Fix

Replace the `count_documents` + `find(..., skip=N)` pair with a single
`find().sort("_id", -1).limit(history_size)` call, followed by a
Python-side `reversed()` to restore chronological order. One round-trip
instead of two.

Also moves `items` assignment inside the `try` block so the `except`
handler can safely fall back to `items = []`.

## Changes

- `libs/langchain-mongodb/langchain_mongodb/chat_message_histories.py`