### PR TITLE
INTPYTHON-1076 Restore pre-existing AWS credentials in aws_credentials fixture teardown

### DIFF
--- a/libs/langchain-mongodb-deepagents-vfs/tests/conftest.py
+++ b/libs/langchain-mongodb-deepagents-vfs/tests/conftest.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import io
-import os
 import textwrap
 from unittest.mock import MagicMock
 
@@ -86,22 +85,22 @@ def _isolate_aws_env(request, monkeypatch):
 
 
 @pytest.fixture(scope="function")
-def aws_credentials():
-    """Fake AWS creds so moto doesn't hit real AWS."""
-    os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-    os.environ["AWS_SECURITY_TOKEN"] = "testing"
-    os.environ["AWS_SESSION_TOKEN"] = "testing"
-    os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+def aws_credentials(monkeypatch):
+    """Fake AWS creds so moto doesn't hit real AWS.
+
+    Uses ``monkeypatch`` rather than assigning to ``os.environ`` directly so
+    that any pre-existing values are *restored* on teardown instead of being
+    deleted.  Deleting them breaks the real-service suites when both run in one
+    pytest process (``pytest tests/e2e_tests``): CI supplies assumed-role
+    credentials as environment variables, and once they are gone botocore falls
+    through to the EC2 instance metadata role.
+    """
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_SECURITY_TOKEN", "testing")
+    monkeypatch.setenv("AWS_SESSION_TOKEN", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
     yield
-    for k in (
-        "AWS_ACCESS_KEY_ID",
-        "AWS_SECRET_ACCESS_KEY",
-        "AWS_SECURITY_TOKEN",
-        "AWS_SESSION_TOKEN",
-        "AWS_DEFAULT_REGION",
-    ):
-        os.environ.pop(k, None)
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
[INTPYTHON-1076](https://jira.mongodb.org/browse/INTPYTHON-1076)

## Summary

The `real_e2e` suites failed in Evergreen with S3 `AccessDenied` naming an unexpected principal:

```
User: arn:aws:sts::557821124784:assumed-role/evergreen_task_hosts_instance_role_production/i-...
is not authorized to perform: s3:PutObject on resource:
"arn:aws:s3:::langchain-mongodb-deepagents-vfs/langchain_mongodb_deepagents_vfs_e2e_test/_preflight_..."
```

This was not an IAM problem. The Evergreen config assumes `drivers_test_secrets_role` correctly and passes the credentials to the test step as environment variables. The test suite was **deleting those credentials mid-run**.

`aws_credentials` set fake moto credentials via direct `os.environ` assignment, then on teardown popped `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` unconditionally — destroying pre-existing values rather than restoring them.

CI runs `just e2e_tests` → `pytest tests/e2e_tests`, so all three files share one process, collected alphabetically:

| Order | File | Effect |
|---|---|---|
| 1 | `test_e2e.py` | moto-backed, uses `aws_credentials` → wipes the credentials |
| 2 | `test_real_e2e.py` | real S3, no env credentials left |
| 3 | `test_watcher_e2e.py` | same |

With the env credentials gone, botocore walked down its credential chain to EC2 instance metadata and picked up the task host's instance role — the unexpected principal in the error.

This only reproduces in CI. Locally credentials come from `AWS_PROFILE`, which the fixture never touched, so profile-based resolution was immune.

## Changes in this PR

`libs/langchain-mongodb-deepagents-vfs/tests/conftest.py`:

- `aws_credentials` now takes `monkeypatch` and uses `monkeypatch.setenv`, which snapshots and restores prior values on teardown. The manual `os.environ.pop` loop is removed.
- Added a docstring recording why, so it isn't reverted to direct `os.environ` use.
- Removed the now-unused `import os`.

No production code changes. `_isolate_aws_env` in the same file already used `monkeypatch` correctly; this brings the credentials fixture in line.

## Test Plan

Verified the mechanism directly with a sentinel value. Before:

```
$ AWS_ACCESS_KEY_ID=SENTINEL_KEY ... pytest tests/e2e_tests/test_e2e.py
AWS_ACCESS_KEY_ID = <<GONE>>
```

After: `AWS_ACCESS_KEY_ID = SENTINEL_KEY`.

| Suite | Result |
|---|---|
| `pytest tests/unit_tests tests/integration_tests` | 160 passed |
| `pytest tests/e2e_tests` against **real AWS S3** + Atlas | 33 passed |
| `ruff check tests/conftest.py` | clean |
| Evergreen CI | passing |

The full `tests/e2e_tests` directory against real S3 is the combination that was previously broken.

Note: one run saw `TestVectorSearch::test_grep_semantic_query` fail on a semantic-ranking assertion, then pass in isolation twice and in a repeat full-directory run. It appears to be a pre-existing flake in that assertion, unrelated to this change; worth a separate ticket.

## Checklist

### Checklist for Author

- [x] Did you update the changelog (if necessary)? N/A — test-only fix
- [x] Is the intention of the code captured in relevant tests? The fixture change is verified by the real-service e2e suites it unblocks
- [x] If there are new TODOs, has a related JIRA ticket been created? No new TODOs
- [x] Has a MongoDB Employee run [the patch build of this PR](https://github.com/mongodb-labs/ai-ml-pipeline-testing?tab=readme-ov-file#running-a-patch-build-of-a-given-pr)? Yes — CI passes with this change

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Is all relevant documentation (README or docstring) updated?
