### PR TITLE
INTPYTHON-1042: Prep langgraph-checkpoint-mongodb 0.5.0 release

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/CHANGELOG.md
+++ b/libs/langgraph-checkpoint-mongodb/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ---
 
+## Changes in version 0.5.0 (2026/09/03)
+- Require Python >=3.11 (dropped support for Python 3.10, which reached End of Life this Fall).
+
 ## Changes in version 0.4.0 (2026/05/11)
 - Reject MQL operator keys (any key containing a "$") in filter dicts.
 - Add links to mongodb.com documentation.

--- a/libs/langgraph-checkpoint-mongodb/pyproject.toml
+++ b/libs/langgraph-checkpoint-mongodb/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "langgraph-checkpoint-mongodb"
-version = "0.4.0"
+version = "0.5.0"
 description = "Library with a MongoDB implementation of LangGraph checkpoint saver."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
@@ -264,7 +264,9 @@ def test_init_creates_indexes() -> None:
 
 
 def test_list_rejects_mql_operator_keys() -> None:
-    with MongoDBSaver.from_conn_string(MONGODB_URI) as saver:
+    with MongoDBSaver.from_conn_string(
+        MONGODB_URI, DB_NAME, "reject_mql_operator_keys"
+    ) as saver:
         # nested operator value — $exists bypass leaks all checkpoints
         with pytest.raises(ValueError, match="MongoDB operator keys are not allowed"):
             list(saver.list(None, filter={"user_id": {"$exists": True}}))

--- a/libs/langgraph-checkpoint-mongodb/uv.lock
+++ b/libs/langgraph-checkpoint-mongodb/uv.lock
@@ -741,7 +741,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-mongodb"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "langchain-mongodb" },

--- a/uv.lock
+++ b/uv.lock
@@ -1399,7 +1399,7 @@ wheels = [
 
 [[package]]
 name = "langgraph-checkpoint-mongodb"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "libs/langgraph-checkpoint-mongodb" }
 dependencies = [
     { name = "langchain-mongodb" },


### PR DESCRIPTION
## Summary

JIRA issue: [INTPYTHON-1042](https://jira.mongodb.org/browse/INTPYTHON-1042)

`requires-python>=3.11` already landed on `main` as a side effect of #415 (INTPYTHON-1028, dropping Python 3.10 support since `langchain-mongodb-deepagents-vfs` requires `>=3.11`), but that change was never released for `langgraph-checkpoint-mongodb` — the version stayed at 0.4.0 and the CHANGELOG made no mention of it.

## Changes
- Bump `version` 0.4.0 → 0.5.0.
- Add a CHANGELOG entry documenting the Python >=3.11 floor (dropped 3.10, which reaches EOL this Fall).
- Regenerate `uv.lock` (package + root).

No other pyproject.toml/dependency changes — this just formalizes and releases a floor bump that was already in effect on `main`, following [INTPYTHON-1068](https://jira.mongodb.org/browse/INTPYTHON-1068) (#448), which cleared the CI warnings blocking this release.

## Test plan
- [ ] `just lint`, `just typing`, `just tests` pass (verified locally: 23 passed)
- [ ] Merge, then run the `_release.yml` workflow for `libs/langgraph-checkpoint-mongodb` per `RELEASE.md`