### PR TITLE
INTPYTHON-1043: Prep langgraph-store-mongodb 0.4.0 release

### DIFF
--- a/libs/langgraph-store-mongodb/CHANGELOG.md
+++ b/libs/langgraph-store-mongodb/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ---
 
-## Changes in version 0.4.0 (XXXX/XX/XX)
+## Changes in version 0.4.0 (2026/09/03)
 
 - Add native reranking (`$rerank`) support to `MongoDBStore.search()`. Pass a
   `RerankConfig` to the `MongoDBStore` constructor to enable reranking of vector
@@ -10,6 +10,7 @@
   Native Reranking enabled in Atlas Project Settings, and a Voyage AI API key
   configured in Atlas. Runs entirely server-side — no Voyage AI client dependency
   is needed.
+- Require Python >=3.11 (dropped support for Python 3.10, which reached End of Life this Fall).
 
 ## Changes in version 0.3.0 (2026/05/11)
 - Fix possible multikey index collision on namespace arrays.


### PR DESCRIPTION
## Summary

JIRA issue: [INTPYTHON-1043](https://jira.mongodb.org/browse/INTPYTHON-1043)

`requires-python>=3.11` already landed on `main` as a side effect of #415 (INTPYTHON-1028, dropping Python 3.10 support since `langchain-mongodb-deepagents-vfs` requires `>=3.11`), but that change was never released for `langgraph-store-mongodb`. The 0.4.0 version bump and its native-reranking CHANGELOG entry were already staged (unreleased, placeholder date), just missing the Python-floor note and an actual date.

## Changes
- Fill in the release date on the already-staged `0.4.0` CHANGELOG entry.
- Add a bullet documenting the Python >=3.11 floor (dropped 3.10, which reaches EOL this Fall).
- No version bump needed (0.4.0 was already staged and unreleased); no lockfile changes needed (no pyproject.toml change).

Follows [INTPYTHON-1068](https://jira.mongodb.org/browse/INTPYTHON-1068) (#448), which cleared the CI warnings blocking this release.

## Test plan
- [ ] `just lint`, `just tests` pass (verified locally: 25 passed, 8 skipped)
- [ ] Merge, then run the `_release.yml` workflow for `libs/langgraph-store-mongodb` per `RELEASE.md`