### PR TITLE
INTPYTHON-1094: Export local Atlas MONGODB_URI to GITHUB_ENV so non-just steps see the dynamic port

### DIFF
--- a/.github/workflows/_release.yml
+++ b/.github/workflows/_release.yml
@@ -151,6 +151,14 @@ jobs:
         working-directory: .
         run: bash scripts/start_local_atlas.sh
 
+      # just's dotenv-load only applies inside just's own process, so steps
+      # that call uv directly (the minimum-dependency-versions step below)
+      # never see the dynamic port start_local_atlas.sh assigned. Exporting
+      # it to $GITHUB_ENV makes it visible to every step in this job.
+      - name: Export local Atlas connection string
+        working-directory: .
+        run: cat .local_atlas_uri >> "$GITHUB_ENV"
+
       - name: Run unit tests
         run: just unit_tests
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -49,6 +49,14 @@ jobs:
         working-directory: .
         run: bash scripts/start_local_atlas.sh
 
+      # just's dotenv-load only applies inside just's own process, so steps
+      # that call uv directly (the minimum-dependency-versions step below)
+      # never see the dynamic port start_local_atlas.sh assigned. Exporting
+      # it to $GITHUB_ENV makes it visible to every step in this job.
+      - name: Export local Atlas connection string
+        working-directory: .
+        run: cat .local_atlas_uri >> "$GITHUB_ENV"
+
       - name: Install Ollama
         run: curl -fsSL https://ollama.com/install.sh | sh
 


### PR DESCRIPTION
## Summary

JIRA issue: [INTPYTHON-1093](https://jira.mongodb.org/browse/INTPYTHON-1093) [INTPYTHON-1094](https://jira.mongodb.org/browse/INTPYTHON-1094)

`scripts/start_local_atlas.sh` starts the local Atlas container with `docker run -P` (random host port mapping), then writes the real connection string to `.local_atlas_uri` at the repo root. Every package's `justfile` sets `dotenv-load` + `dotenv-filename := "../../.local_atlas_uri"`, so any `just <recipe>` invocation picks up the correct dynamic `MONGODB_URI`. But `just`'s dotenv loading only applies inside `just`'s own process — it's never exported to the parent GitHub Actions shell.

The "Run unit tests with minimum dependency versions" step in both `_test.yml` and `_release.yml` is the only test step in its job that calls `uv sync`/`uv run` directly instead of via `just` (deliberately, to avoid `uv run` re-syncing away the lowest-direct resolution). That step never saw `.local_atlas_uri`, so it fell back to each test file's hardcoded default (`mongodb://localhost:27017`), which is wrong whenever the container's random port isn't literally 27017.

In `_release.yml` (only Mongo service is local Atlas), this was a hard `ServerSelectionTimeoutError: Connection refused` — hit while attempting to release `langgraph-store-mongodb` 0.4.0: https://github.com/langchain-ai/langchain-mongodb/actions/runs/33805996244/job/100816586312

In `_test.yml` (which also runs a separate community MongoDB on the fixed default port for the earlier "Run unit tests" step), the same fallback silently connected to *that* deployment instead of local Atlas — a quieter version of the same bug.

## Fix
Added a step right after "Start local Atlas" in both workflows:
```
cat .local_atlas_uri >> "$GITHUB_ENV"
```
This exports `MONGODB_URI` for every later step in the job, `just`-wrapped or not. `start_local_atlas.sh`'s random-port behavior and `_test.yml`'s separate community-MongoDB step are left unchanged — only the propagation gap needed fixing.

## Verification
- Both workflow files pass the repo's `check-github-workflows` pre-commit schema validation.
- Verified locally: sourced `.local_atlas_uri` and ran `uv run --no-sync pytest` directly (bypassing `just`, matching the CI step) — correctly targeted the dynamic-port container (port 55000 in this run) instead of whatever happens to be listening on 27017. 23/23 passed.

Note: `_release.yml`'s `build` job is gated to `github.ref == 'refs/heads/main'`, so this fix can't be dry-run end-to-end via a normal PR — only `_test.yml`'s equivalent step runs off a branch, and even that won't reproduce the exact failure mode (it silently passes against the wrong Mongo rather than crashing) due to the redundant community-Mongo service there.

## Test plan
- [ ] `_test.yml` runs green on this PR
- [ ] Next actual release run (e.g. re-attempting langgraph-store-mongodb 0.4.0) confirms the minimum-deps step passes against local Atlas