### PR TITLE
INTPYTHON-1095: Fix test_ttl racing MongoDB's TTL monitor

### DIFF
--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
@@ -208,7 +208,14 @@ def test_ttl(input_data: dict[str, Any]) -> None:
             assert len(search_results_2) == 1
             assert search_results_2[0].metadata == input_data["metadata_2"]
 
-            sleep(ttl + monitor_period)
+            # ttlMonitorSleepSecs sets the interval between TTL sweeps, not a
+            # deadline: worst case, a sweep just finished as the document
+            # became eligible, so the next one is up to a full monitor_period
+            # away. sleep(ttl + monitor_period) asserted almost exactly that
+            # worst case with zero room for the delete's own execution time,
+            # so it raced the background thread. +1s covers that latency -
+            # a small fixed allowance, not a multiple of ttl or monitor_period.
+            sleep(ttl + monitor_period + 1)
             assert len(list(saver.list(None, filter=query))) == 0
 
         finally:

--- a/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
+++ b/libs/langgraph-checkpoint-mongodb/tests/unit_tests/test_sync.py
@@ -176,11 +176,21 @@ def test_nested_filter() -> None:
 
 
 def test_ttl(input_data: dict[str, Any]) -> None:
+    """Checkpoints past their TTL are swept and removed.
+
+    ttl: seconds a checkpoint may live before it's eligible for deletion.
+    monitor_period: ttlMonitorSleepSecs, the interval between MongoDB's
+        background TTL sweeps - a scheduling interval, not a deadline.
+        Worst case, a sweep just finished as the document became
+        eligible, so the next one is up to a full monitor_period away.
+    some_latency: small fixed allowance for the sweep's own execution
+        time to make this test reliable.
+    """
     collection_name = "ttl_test"
     ttl = 1
-
-    # Set period between background task runs.
     monitor_period = 2
+    some_latency = 1
+
     client: MongoClient = MongoClient(MONGODB_URI)
     try:
         # This works for local Atlas CLI.
@@ -208,14 +218,7 @@ def test_ttl(input_data: dict[str, Any]) -> None:
             assert len(search_results_2) == 1
             assert search_results_2[0].metadata == input_data["metadata_2"]
 
-            # ttlMonitorSleepSecs sets the interval between TTL sweeps, not a
-            # deadline: worst case, a sweep just finished as the document
-            # became eligible, so the next one is up to a full monitor_period
-            # away. sleep(ttl + monitor_period) asserted almost exactly that
-            # worst case with zero room for the delete's own execution time,
-            # so it raced the background thread. +1s covers that latency -
-            # a small fixed allowance, not a multiple of ttl or monitor_period.
-            sleep(ttl + monitor_period + 1)
+            sleep(ttl + monitor_period + some_latency)
             assert len(list(saver.list(None, filter=query))) == 0
 
         finally:


### PR DESCRIPTION
## Summary

JIRA issue: [INTPYTHON-1095](https://jira.mongodb.org/browse/INTPYTHON-1095)

`tests/unit_tests/test_sync.py::test_ttl` sets `ttl=1` second and `ttlMonitorSleepSecs=2` (the interval between MongoDB's background TTL sweeps), then did a single `sleep(ttl + monitor_period)` (3 seconds total) before asserting the expired checkpoint was gone.

`ttlMonitorSleepSecs` controls the interval *between* sweeps, not a deadline: worst case, a sweep just completed as the document became eligible, so the next one is up to a full `monitor_period` away, plus the delete itself takes non-zero time. The old fixed sleep asserted almost exactly that worst case with zero margin, so it raced the background thread.

Hit in a real release run for `langgraph-checkpoint-mongodb` 0.5.0 (INTPYTHON-1042, merged): `AssertionError: assert 1 == 0` — the checkpoint hadn't been swept yet. Job: https://github.com/langchain-ai/langchain-mongodb/actions/runs/33817503742/job/100852843438

## Fix
Added a small, fixed `some_latency = 1` second allowance on top of the true worst case (`ttl + monitor_period`) — additive, not a multiple of `ttl` or `monitor_period`, so a TTL of X doesn't become a TTL of 5*X just to make the test reliable. Also moved the timing explanation (`ttl`, `monitor_period`, `some_latency`) into the function's docstring rather than an inline comment.

## Verification
- `just lint`, `just typing` pass.
- Ran `test_ttl` 5x consecutively against a real local-Atlas container — all pass in ~4.1s each (vs. the old fixed 3s that raced).

## Test plan
- [ ] CI green